### PR TITLE
update wolfssl and examples to 3.15.7 release

### DIFF
--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/benchmark.c
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/benchmark.c
@@ -60,6 +60,11 @@
 
     #undef printf
     #define printf PRINTF
+#elif defined(MICRIUM)
+      #include <bsp_ser.h>
+      void BSP_Ser_Printf (CPU_CHAR* format, ...);
+      #undef printf
+      #define printf BSP_Ser_Printf
 #else
     #include <stdio.h>
 #endif
@@ -415,6 +420,7 @@ static const bench_alg bench_other_opt[] = {
 #endif
 
 static int lng_index = 0;
+#ifndef NO_MAIN_DRIVER
 static const char* bench_Usage_msg1[][10] = {
     /* 0 English  */
     {   "-? <num>    Help, print this usage\n            0: English, 1: Japanese\n",
@@ -428,6 +434,7 @@ static const char* bench_Usage_msg1[][10] = {
         "-lng <num>  Display benchmark result by specified language.\n            0: English, 1: Japanese\n",
         "<num>       Size of block in bytes\n",
     },
+#ifndef NO_MULTIBYTE_PRINT
     /* 1 Japanese */
     {   "-? <num>    ヘルプ, 使い方を表示します。\n            0: 英語、 1: 日本語\n",
         "-csv        csv 形式で端末に出力します。\n",
@@ -439,15 +446,19 @@ static const char* bench_Usage_msg1[][10] = {
         "-<alg>      アルゴリズムのベンチマークを実施します。\n            利用可能なアルゴリズムは下記を含みます:\n",
         "-lng <num>  指定された言語でベンチマーク結果を表示します。\n            0: 英語、 1: 日本語\n",
         "<num>       ブロックサイズをバイト単位で指定します。\n",
-    }, 
+    },
+#endif
 };
+#endif
 
 static const char* bench_result_words1[][4] = {
-    { "tooks", "seconds" , "Cycles per byte", NULL },               /* 0 English  */
+    { "took", "seconds" , "Cycles per byte", NULL },           /* 0 English  */
+#ifndef NO_MULTIBYTE_PRINT
     { "を"   , "秒で処理", "1バイトあたりのサイクル数", NULL },     /* 1 Japanese */
+#endif
 };
 
-#if !defined(NO_RSA)  ||defined(WOLFSSL_KEY_GEN) || defined(HAVE_NTRU) || \
+#if !defined(NO_RSA) || defined(WOLFSSL_KEY_GEN) || defined(HAVE_NTRU) || \
     defined(HAVE_ECC) || !defined(NO_DH) || defined(HAVE_ECC_ENCRYPT) || \
     defined(HAVE_CURVE25519) || defined(HAVE_CURVE25519_SHARED_SECRET)  || \
     defined(HAVE_ED25519)
@@ -455,7 +466,9 @@ static const char* bench_result_words1[][4] = {
 static const char* bench_desc_words[][9] = {
     /* 0           1          2         3        4        5         6            7            8 */
     {"public", "private", "key gen", "agree" , "sign", "verify", "encryption", "decryption", NULL}, /* 0 English */
-    {"公開鍵", "秘密鍵" ,"鍵生成" , "鍵共有" , "署名", "検証"  , "暗号化"    , "復号化"    , NULL}, /* 1 Japanese */     
+#ifndef NO_MULTIBYTE_PRINT
+    {"公開鍵", "秘密鍵" ,"鍵生成" , "鍵共有" , "署名", "検証"  , "暗号化"    , "復号化"    , NULL}, /* 1 Japanese */
+#endif
 };
 
 #endif
@@ -559,7 +572,7 @@ static const char* bench_desc_words[][9] = {
 #endif
 #endif
 
-#if !defined(NO_RSA) || !defined(NO_DH) \
+#if (!defined(NO_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || !defined(NO_DH) \
                         || defined(WOLFSSL_KEYGEN) || defined(HAVE_ECC) \
                         || defined(HAVE_CURVE25519) || defined(HAVE_ED25519)
     #define HAVE_LOCAL_RNG
@@ -569,14 +582,15 @@ static const char* bench_desc_words[][9] = {
 #if defined(HAVE_ED25519) || defined(HAVE_CURVE25519) || defined(HAVE_ECC) || \
     defined(HAVE_ECC) || defined(HAVE_NTRU) || !defined(NO_DH) || \
     !defined(NO_RSA) || defined(HAVE_SCRYPT)
-
     #define BENCH_ASYM
 #endif
 
 #if defined(BENCH_ASYM)
 static const char* bench_result_words2[][5] = {
     { "ops took", "sec"     , "avg" , "ops/sec", NULL },            /* 0 English  */
+#ifndef NO_MULTIBYTE_PRINT
     { "回処理を", "秒で実施", "平均", "処理/秒", NULL },            /* 1 Japanese */
+#endif
 };
 #endif
 
@@ -765,7 +779,9 @@ static int rsa_sign_verify = 0;
 
 /* Don't print out in CSV format by default */
 static int csv_format = 0;
+#ifdef BENCH_ASYM
 static int csv_header_count = 0;
+#endif
 
 /* for compatibility */
 #define BENCH_SIZE bench_size
@@ -981,7 +997,7 @@ static void bench_stats_sym_finish(const char* desc, int doAsync, int count,
         SHOW_INTEL_CYCLES_CSV(msg, sizeof(msg), countSz);
     } else {
         XSNPRINTF(msg, sizeof(msg), "%-16s%s %5.0f %s %s %5.3f %s, %8.3f %s/s",
-        desc, BENCH_ASYNC_GET_NAME(doAsync), blocks, blockType, word[0], total, word[1], 
+        desc, BENCH_ASYNC_GET_NAME(doAsync), blocks, blockType, word[0], total, word[1],
         persec, blockType);
         SHOW_INTEL_CYCLES(msg, sizeof(msg), countSz);
     }
@@ -1436,16 +1452,13 @@ static void* benchmarks_do(void* args)
                 bench_rsaKeyGen(0);
             }
         #endif
-        #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_RSA)
-            /* async supported in simulator only */
-            #ifdef WOLFSSL_ASYNC_CRYPT_TEST
+        #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_RSA_KEYGEN)
             if (bench_asym_algs & BENCH_RSA_SZ) {
                 bench_rsaKeyGen_size(1, bench_size);
             }
             else {
                 bench_rsaKeyGen(1);
             }
-            #endif
         #endif
         }
     #endif
@@ -1641,11 +1654,9 @@ int benchmark_test(void *args)
 
     (void)args;
 
-    printf(
-"------------------------------------------------------------------------------"
-"\n wolfSSL version %s\n"
-"------------------------------------------------------------------------------"
-"\n", LIBWOLFSSL_VERSION_STRING);
+    printf("------------------------------------------------------------------------------\n");
+    printf(" wolfSSL version %s\n", LIBWOLFSSL_VERSION_STRING);
+    printf("------------------------------------------------------------------------------\n");
 
     ret = benchmark_init();
     if (ret != 0)
@@ -1859,7 +1870,9 @@ static void bench_aesgcm_internal(int doAsync, const byte* key, word32 keySz,
 {
     int    ret = 0, i, count = 0, times, pending = 0;
     Aes    enc[BENCH_MAX_PENDING];
+#ifdef HAVE_AES_DECRYPT
     Aes    dec[BENCH_MAX_PENDING];
+#endif
     double start;
 
     DECLARE_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
@@ -1867,14 +1880,17 @@ static void bench_aesgcm_internal(int doAsync, const byte* key, word32 keySz,
 
     /* clear for done cleanup */
     XMEMSET(enc, 0, sizeof(enc));
+#ifdef HAVE_AES_DECRYPT
+    XMEMSET(dec, 0, sizeof(dec));
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (bench_additional)
 #endif
-    {   XMEMSET(bench_additional, 0, AES_AUTH_ADD_SZ); }
+        XMEMSET(bench_additional, 0, AES_AUTH_ADD_SZ);
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (bench_tag)
 #endif
-    {   XMEMSET(bench_tag, 0, AES_AUTH_TAG_SZ); }
+        XMEMSET(bench_tag, 0, AES_AUTH_TAG_SZ);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
@@ -1953,10 +1969,6 @@ exit_aes_gcm:
     } while (bench_stats_sym_check(start));
 exit_aes_gcm_dec:
     bench_stats_sym_finish(decLabel, doAsync, count, bench_size, start, ret);
-
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&dec[i]);
-    }
 #endif /* HAVE_AES_DECRYPT */
 
     (void)decLabel;
@@ -1966,7 +1978,11 @@ exit:
     if (ret < 0) {
         printf("bench_aesgcm failed: %d\n", ret);
     }
-
+#ifdef HAVE_AES_DECRYPT
+    for (i = 0; i < BENCH_MAX_PENDING; i++) {
+        wc_AesFree(&dec[i]);
+    }
+#endif
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
         wc_AesFree(&enc[i]);
     }
@@ -3849,21 +3865,142 @@ void bench_rsaKeyGen_size(int doAsync, int keySz)
 
 #define RSA_BUF_SIZE 384  /* for up to 3072 bit */
 
+#if !defined(WOLFSSL_RSA_VERIFY_INLINE) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)
+#elif defined(USE_CERT_BUFFERS_2048)
+static unsigned char rsa_2048_sig[] = {
+    0x8c, 0x9e, 0x37, 0xbf, 0xc3, 0xa6, 0xba, 0x1c,
+    0x53, 0x22, 0x40, 0x4b, 0x8b, 0x0d, 0x3c, 0x0e,
+    0x2e, 0x8c, 0x31, 0x2c, 0x47, 0xbf, 0x03, 0x48,
+    0x18, 0x46, 0x73, 0x8d, 0xd7, 0xdd, 0x17, 0x64,
+    0x0d, 0x7f, 0xdc, 0x74, 0xed, 0x80, 0xc3, 0xe8,
+    0x9a, 0x18, 0x33, 0xd4, 0xe6, 0xc5, 0xe1, 0x54,
+    0x75, 0xd1, 0xbb, 0x40, 0xde, 0xa8, 0xb9, 0x1b,
+    0x14, 0xe8, 0xc1, 0x39, 0xeb, 0xa0, 0x69, 0x8a,
+    0xc6, 0x9b, 0xef, 0x53, 0xb5, 0x23, 0x2b, 0x78,
+    0x06, 0x43, 0x37, 0x11, 0x81, 0x84, 0x73, 0x33,
+    0x33, 0xfe, 0xf7, 0x5d, 0x2b, 0x84, 0xd6, 0x83,
+    0xd6, 0xdd, 0x55, 0x33, 0xef, 0xd1, 0xf7, 0x12,
+    0xb0, 0xc2, 0x0e, 0xb1, 0x78, 0xd4, 0xa8, 0xa3,
+    0x25, 0xeb, 0xed, 0x9a, 0xb3, 0xee, 0xc3, 0x7e,
+    0xce, 0x13, 0x18, 0x86, 0x31, 0xe1, 0xef, 0x01,
+    0x0f, 0x6e, 0x67, 0x24, 0x74, 0xbd, 0x0b, 0x7f,
+    0xa9, 0xca, 0x6f, 0xaa, 0x83, 0x28, 0x90, 0x40,
+    0xf1, 0xb5, 0x10, 0x0e, 0x26, 0x03, 0x05, 0x5d,
+    0x87, 0xb4, 0xe0, 0x4c, 0x98, 0xd8, 0xc6, 0x42,
+    0x89, 0x77, 0xeb, 0xb6, 0xd4, 0xe6, 0x26, 0xf3,
+    0x31, 0x25, 0xde, 0x28, 0x38, 0x58, 0xe8, 0x2c,
+    0xf4, 0x56, 0x7c, 0xb6, 0xfd, 0x99, 0xb0, 0xb0,
+    0xf4, 0x83, 0xb6, 0x74, 0xa9, 0x5b, 0x9f, 0xe8,
+    0xe9, 0xf1, 0xa1, 0x2a, 0xbd, 0xf6, 0x83, 0x28,
+    0x09, 0xda, 0xa6, 0xd6, 0xcd, 0x61, 0x60, 0xf7,
+    0x13, 0x4e, 0x46, 0x57, 0x38, 0x1e, 0x11, 0x92,
+    0x6b, 0x6b, 0xcf, 0xd3, 0xf4, 0x8b, 0x66, 0x03,
+    0x25, 0xa3, 0x7a, 0x2f, 0xce, 0xc1, 0x85, 0xa5,
+    0x48, 0x91, 0x8a, 0xb3, 0x4f, 0x5d, 0x98, 0xb1,
+    0x69, 0x58, 0x47, 0x69, 0x0c, 0x52, 0xdc, 0x42,
+    0x4c, 0xef, 0xe8, 0xd4, 0x4d, 0x6a, 0x33, 0x7d,
+    0x9e, 0xd2, 0x51, 0xe6, 0x41, 0xbf, 0x4f, 0xa2
+};
+#elif defined(USE_CERT_BUFFERS_3072)
+static unsigned char rsa_3072_sig[] = {
+    0x1a, 0xd6, 0x0d, 0xfd, 0xe3, 0x41, 0x95, 0x76,
+    0x27, 0x16, 0x7d, 0xc7, 0x94, 0x16, 0xca, 0xa8,
+    0x26, 0x08, 0xbe, 0x78, 0x87, 0x72, 0x4c, 0xd9,
+    0xa7, 0xfc, 0x33, 0x77, 0x2d, 0x53, 0x07, 0xb5,
+    0x8c, 0xce, 0x48, 0x17, 0x9b, 0xff, 0x9f, 0x9b,
+    0x17, 0xc4, 0xbb, 0x72, 0xed, 0xdb, 0xa0, 0x34,
+    0x69, 0x5b, 0xc7, 0x4e, 0xbf, 0xec, 0x13, 0xc5,
+    0x98, 0x71, 0x9a, 0x4e, 0x18, 0x0e, 0xcb, 0xe7,
+    0xc6, 0xd5, 0x21, 0x31, 0x7c, 0x0d, 0xae, 0x14,
+    0x2b, 0x87, 0x4f, 0x77, 0x95, 0x2e, 0x26, 0xe2,
+    0x83, 0xfe, 0x49, 0x1e, 0x87, 0x19, 0x4a, 0x63,
+    0x73, 0x75, 0xf1, 0xf5, 0x71, 0xd2, 0xce, 0xd4,
+    0x39, 0x2b, 0xd9, 0xe0, 0x76, 0x70, 0xc8, 0xf8,
+    0xed, 0xdf, 0x90, 0x57, 0x17, 0xb9, 0x16, 0xf6,
+    0xe9, 0x49, 0x48, 0xce, 0x5a, 0x8b, 0xe4, 0x84,
+    0x7c, 0xf3, 0x31, 0x68, 0x97, 0x45, 0x68, 0x38,
+    0x50, 0x3a, 0x70, 0xbd, 0xb3, 0xd3, 0xd2, 0xe0,
+    0x56, 0x5b, 0xc2, 0x0c, 0x2c, 0x10, 0x70, 0x7b,
+    0xd4, 0x99, 0xf9, 0x38, 0x31, 0xb1, 0x86, 0xa0,
+    0x07, 0xf1, 0xf6, 0x53, 0xb0, 0x44, 0x82, 0x40,
+    0xd2, 0xab, 0x0e, 0x71, 0x5d, 0xe1, 0xea, 0x3a,
+    0x77, 0xc9, 0xef, 0xfe, 0x54, 0x65, 0xa3, 0x49,
+    0xfd, 0xa5, 0x33, 0xaa, 0x16, 0x1a, 0x38, 0xe7,
+    0xaa, 0xb7, 0x13, 0xb2, 0x3b, 0xc7, 0x00, 0x87,
+    0x12, 0xfe, 0xfd, 0xf4, 0x55, 0x6d, 0x1d, 0x4a,
+    0x0e, 0xad, 0xd0, 0x4c, 0x55, 0x91, 0x60, 0xd9,
+    0xef, 0x74, 0x69, 0x22, 0x8c, 0x51, 0x65, 0xc2,
+    0x04, 0xac, 0xd3, 0x8d, 0xf7, 0x35, 0x29, 0x13,
+    0x6d, 0x61, 0x7c, 0x39, 0x2f, 0x41, 0x4c, 0xdf,
+    0x38, 0xfd, 0x1a, 0x7d, 0x42, 0xa7, 0x6f, 0x3f,
+    0x3d, 0x9b, 0xd1, 0x97, 0xab, 0xc0, 0xa7, 0x28,
+    0x1c, 0xc0, 0x02, 0x26, 0xeb, 0xce, 0xf9, 0xe1,
+    0x34, 0x45, 0xaf, 0xbf, 0x8d, 0xb8, 0xe0, 0xff,
+    0xd9, 0x6f, 0x77, 0xf3, 0xf7, 0xed, 0x6a, 0xbb,
+    0x03, 0x52, 0xfb, 0x38, 0xfc, 0xea, 0x9f, 0xc9,
+    0x98, 0xed, 0x21, 0x45, 0xaf, 0x43, 0x2b, 0x64,
+    0x96, 0x82, 0x30, 0xe9, 0xb4, 0x36, 0x89, 0x77,
+    0x07, 0x4a, 0xc6, 0x1f, 0x38, 0x7a, 0xee, 0xb6,
+    0x86, 0xf6, 0x2f, 0x03, 0xec, 0xa2, 0xe5, 0x48,
+    0xe5, 0x5a, 0xf5, 0x1c, 0xd2, 0xd9, 0xd8, 0x2d,
+    0x9d, 0x06, 0x07, 0xc9, 0x8b, 0x5d, 0xe0, 0x0f,
+    0x5e, 0x0c, 0x53, 0x27, 0xff, 0x23, 0xee, 0xca,
+    0x5e, 0x4d, 0xf1, 0x95, 0x77, 0x78, 0x1f, 0xf2,
+    0x44, 0x5b, 0x7d, 0x01, 0x49, 0x61, 0x6f, 0x6d,
+    0xbf, 0xf5, 0x19, 0x06, 0x39, 0xe9, 0xe9, 0x29,
+    0xde, 0x47, 0x5e, 0x2e, 0x1f, 0x68, 0xf4, 0x32,
+    0x5e, 0xe9, 0xd0, 0xa7, 0xb4, 0x2a, 0x45, 0xdf,
+    0x15, 0x7d, 0x0d, 0x5b, 0xef, 0xc6, 0x23, 0xac
+};
+#else
+    #error Not Supported Yet!
+#endif
+
 static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
         int rsaKeySz)
 {
     int         ret = 0, i, times, count = 0, pending = 0;
     word32      idx = 0;
+#ifndef WOLFSSL_RSA_VERIFY_ONLY
     const char* messageStr = "Everyone gets Friday off.";
     const int   len = (int)XSTRLEN((char*)messageStr);
+#endif
     double      start = 0.0f;
     const char**desc = bench_desc_words[lng_index];
-
+#ifndef WOLFSSL_RSA_VERIFY_ONLY
     DECLARE_VAR_INIT(message, byte, len, messageStr, HEAP_HINT);
-    DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
-    DECLARE_ARRAY(out, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
+#endif
+
+    #ifdef USE_CERT_BUFFERS_1024
+        DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, 128, HEAP_HINT);
+        #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
+                        !defined(WOLFSSL_RSA_PUBLIC_ONLY)
+            DECLARE_ARRAY(out, byte, BENCH_MAX_PENDING, 128, HEAP_HINT);
+        #else
+            byte* out[BENCH_MAX_PENDING];
+        #endif
+    #elif defined(USE_CERT_BUFFERS_2048)
+        DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, 256, HEAP_HINT);
+        #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
+                        !defined(WOLFSSL_RSA_PUBLIC_ONLY)
+            DECLARE_ARRAY(out, byte, BENCH_MAX_PENDING, 256, HEAP_HINT);
+        #else
+            byte* out[BENCH_MAX_PENDING];
+        #endif
+    #elif defined(USE_CERT_BUFFERS_3072)
+        DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, 384, HEAP_HINT);
+        #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
+                        !defined(WOLFSSL_RSA_PUBLIC_ONLY)
+            DECLARE_ARRAY(out, byte, BENCH_MAX_PENDING, 384, HEAP_HINT);
+        #else
+            byte* out[BENCH_MAX_PENDING];
+        #endif
+    #else
+        #error "need a cert buffer size"
+    #endif /* USE_CERT_BUFFERS */
 
     if (!rsa_sign_verify) {
+#ifndef WOLFSSL_RSA_VERIFY_ONLY
         /* begin public RSA */
         bench_stats_start(&count, &start);
         do {
@@ -3889,7 +4026,9 @@ static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
 exit_rsa_pub:
         bench_stats_asym_finish("RSA", rsaKeySz, desc[0], doAsync, count,
                                                                     start, ret);
+#endif
 
+#ifndef WOLFSSL_RSA_PUBLIC_ONLY
         if (ret < 0) {
             goto exit;
         }
@@ -3922,8 +4061,10 @@ exit_rsa_pub:
 exit:
         bench_stats_asym_finish("RSA", rsaKeySz, desc[1], doAsync, count,
                                                                     start, ret);
+#endif
     }
     else {
+#ifndef WOLFSSL_RSA_PUBLIC_ONLY
         /* begin RSA sign */
         bench_stats_start(&count, &start);
         do {
@@ -3953,6 +4094,7 @@ exit_rsa_sign:
         if (ret < 0) {
             goto exit;
         }
+#endif
 
         /* capture resulting encrypt length */
         idx = rsaKeySz/8;
@@ -3967,8 +4109,27 @@ exit_rsa_sign:
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
+                    #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
+                        !defined(WOLFSSL_RSA_PUBLIC_ONLY)
                         ret = wc_RsaSSL_Verify(enc[i], idx, out[i],
                                                       rsaKeySz/8, &rsaKey[i]);
+                    #elif defined(USE_CERT_BUFFERS_2048)
+                        XMEMCPY(enc[i], rsa_2048_sig, sizeof(rsa_2048_sig));
+                        idx = sizeof(rsa_2048_sig);
+                        out[i] = NULL;
+                        ret = wc_RsaSSL_VerifyInline(enc[i], idx, &out[i],
+                                                                    &rsaKey[i]);
+                        if (ret > 0)
+                            ret = 0;
+                    #elif defined(USE_CERT_BUFFERS_3072)
+                        XMEMCPY(enc[i], rsa_3072_sig, sizeof(rsa_3072_sig));
+                        idx = sizeof(rsa_3072_sig);
+                        out[i] = NULL;
+                        ret = wc_RsaSSL_VerifyInline(enc[i], idx, &out[i],
+                                                                    &rsaKey[i]);
+                        if (ret > 0)
+                            ret = 0;
+                    #endif
                         if (!bench_async_handle(&ret,
                                                 BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                 1, &times, &pending)) {
@@ -4426,6 +4587,7 @@ void bench_ntruKeyGen(void)
     word16 ntruBits = 128;
     word16 type     = 0;
     word32 ret;
+    const char**desc = bench_desc_words[lng_index];
 
     DRBG_HANDLE drbg;
     static uint8_t const pers_str[] = {
@@ -4990,10 +5152,14 @@ exit_ed_verify:
     /* declared above at line 239 */
     /* extern   double current_time(int reset); */
 
-#elif defined FREERTOS
+#elif defined(FREERTOS)
 
     #include "task.h"
-
+#if defined(WOLFSSL_ESPIDF)
+    /* proto type definition */
+    int construct_argv();
+    extern char* __argv[22];
+#endif
     double current_time(int reset)
     {
         portTickType tickCount;
@@ -5044,6 +5210,14 @@ exit_ed_verify:
 #elif defined(WOLFSSL_SGX)
     double current_time(int reset);
 
+#elif defined(MICRIUM)
+    double current_time(int reset)
+    {
+        CPU_ERR err;
+
+        (void)reset;
+        return (double) CPU_TS_Get32()/CPU_TS_TmrFreqGet(&err);
+    }
 #else
 
     #include <sys/time.h>
@@ -5170,11 +5344,18 @@ static int string_matches(const char* arg, const char* str)
     int len = (int)XSTRLEN(str) + 1;
     return XSTRNCMP(arg, str, len) == 0;
 }
-
+#ifdef WOLFSSL_ESPIDF
+int app_main( )
+#else
 int main(int argc, char** argv)
+#endif
 {
     int ret = 0;
     int optMatched;
+#ifdef WOLFSSL_ESPIDF
+    int argc = construct_argv();
+    char** argv = (char**)__argv;
+#endif
 #ifndef WOLFSSL_BENCHMARK_ALL
     int i;
 #endif
@@ -5220,10 +5401,12 @@ int main(int argc, char** argv)
         else if (string_matches(argv[1], "-rsa_sign"))
             rsa_sign_verify = 1;
 #endif
+#ifdef BENCH_ASYM
         else if (string_matches(argv[1], "-csv")) {
             csv_format = 1;
             csv_header_count = 1;
         }
+#endif
         else if (argv[1][0] == '-') {
             optMatched = 0;
 #ifndef WOLFSSL_BENCHMARK_ALL

--- a/recipes-wolfssl/wolfssl/wolfssl_3.15.7.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_3.15.7.bb
@@ -12,9 +12,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 PROVIDES += "cyassl"
 RPROVIDES_${PN} = "cyassl"
 
-SRC_URI[md5sum] = "bc2dff70ba6e91aa3748d36ae6c6bc3d"
-SRC_URI[sha256sum] = "f6c04c25355b340373931f43f8041b3cef78b61122e8a8edf9ee63c07b7a58be"
-SRC_URI = "https://www.wolfssl.com/wolfssl-3.15.5.zip"
+SRC_URI[md5sum] = "6ec08c09e3f51cccbb1686b4fd45f92f"
+SRC_URI[sha256sum] = "4cc318c49580d3b9c361fe258fac6106624aa744f1d34e03977b587766a753ee"
+SRC_URI = "https://www.wolfssl.com/wolfssl-3.15.7.zip"
 
 inherit autotools
 


### PR DESCRIPTION
This PR updates the meta-wolfssl wolfSSL recipe to the current 3.15.7 release.

Since the wolfcrypt test and benchmark apps currently contain copies of wolfSSL's test.c and benchmark.c, this also updates those recipes to match the ones distributed in the 3.15.7 release.