### PR TITLE
layer.conf: define LAYERSERIES_COMPAT to prevent warnings during build

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,3 +12,5 @@ BBFILE_PRIORITY_wolfssl = "5"
 
 # Yocto manual recommends a space before this list to prevent conflicts
 IMAGE_INSTALL_append = " wolfssl"
+
+LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus dunfell"


### PR DESCRIPTION
To prevent warnings during the build.

Source: https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#var-LAYERSERIES_COMPAT
<Quote>
Lists the versions of the OpenEmbedded-Core for which a layer is compatible. Using the LAYERSERIES_COMPAT variable allows the layer maintainer to indicate which combinations of the layer and OE-Core can be expected to work. The variable gives the system a way to detect when a layer has not been tested with new releases of OE-Core (e.g. the layer is not maintained).

To specify the OE-Core versions for which a layer is compatible, use this variable in your layer's conf/layer.conf configuration file. For the list, use the Yocto Project Release Name (e.g. dunfell). To specify multiple OE-Core versions for the layer, use a space-separated list:

     LAYERSERIES_COMPAT_layer_root_name = "dunfell zeus"
                    

Note
Setting LAYERSERIES_COMPAT is required by the Yocto Project Compatible version 2 standard. The OpenEmbedded build system produces a warning if the variable is not set for any given layer. 
</Quote>