### PR TITLE
Added Yocto 3.0 Zeus to the list of compatible oe-core layers

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,5 +14,5 @@ BBFILE_PRIORITY_wolfssl = "5"
 IMAGE_INSTALL_append = " wolfssl"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
-LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior"
+LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus"
 


### PR DESCRIPTION
After testing, I can confirm that the meta-wolfssl successfully builds with the official Yocto 3.0 Zeus release.

This is a simple one-liner commit, but it extends the meta to work seamlessly for Yocto 3.0

Otherwise, the user would get an error for incompatible layer.

