### PR TITLE
update wolfSSL from 5.0.0 to 5.1.1

### DIFF
--- a/recipes-wolfssl/wolfssl/wolfssl_5.1.1.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.1.1.bb
@@ -14,7 +14,7 @@ RPROVIDES_${PN} = "cyassl"
 PROVIDES += "wolfssl"
 RPROVIDES_${PN} = "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssl.git;tag=v${PV}-stable"
+SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;tag=v${PV}-stable;"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This PR updates the wolfSSL recipe version from 5.0.0-stable to 5.1.1-stable.  Also needed to add `nobranch=1` since the tag commit is not on a branch for v5.1.1-stable.