### PR TITLE
meta-wolfssl: enable layer for Yocto Gatesgarth

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,5 +14,5 @@ BBFILE_PRIORITY_wolfssl = "5"
 IMAGE_INSTALL_append = " wolfssl"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
-LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus dunfell hardknott"
+LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus dunfell gatesgarth hardknott"
 


### PR DESCRIPTION
A basic test of Yocto 3.2 seems to be working fine. Otherwise an
out-of-tree patch (or a fork) is needed just to use WolfSSL on Yocto
3.2.

Signed-off-by: Javier Viguera <javier.viguera@digi.com>