### PR TITLE
Don't add .bbappends for ports by default.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -2,9 +2,17 @@
 BBPATH := "${LAYERDIR}:${BBPATH}"
 
 # We have a packages directory, add to BBFILES
-BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
-            ${LAYERDIR}/recipes-*/*/*/*.bb \
-            ${LAYERDIR}/recipes-*/*/*.bbappend"
+BBFILES += "${LAYERDIR}/recipes-wolfssl/*/*.bb \
+            ${LAYERDIR}/recipes-wolfssl/*/*.bbappend"
+
+BBFILES += "${LAYERDIR}/recipes-examples/*/*/*.bb \
+            ${LAYERDIR}/recipes-examples/*/*/*.bbappend"
+
+# Uncomment if building curl with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-support/curl/*.bbappend"
+
+# Uncomment if building OpenSSH with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-connectivity/openssh/*.bbappend"
 
 BBFILE_COLLECTIONS += "wolfssl"
 BBFILE_PATTERN_wolfssl := "^${LAYERDIR}/"
@@ -14,5 +22,5 @@ BBFILE_PRIORITY_wolfssl = "5"
 IMAGE_INSTALL_append = " wolfssl"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
-LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus dunfell hardknott gatesgarth"
-
+LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus dunfell hardknott \
+                              gatesgarth"


### PR DESCRIPTION
Users should have to opt in to using our ports for various open source projects (e.g. curl). This commit makes it so.