### PR TITLE
Add support for several OSP ports.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,11 +8,32 @@ BBFILES += "${LAYERDIR}/recipes-wolfssl/*/*.bb \
 BBFILES += "${LAYERDIR}/recipes-examples/*/*/*.bb \
             ${LAYERDIR}/recipes-examples/*/*/*.bbappend"
 
+# Uncomment if building bind with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-connectivity/bind/*.bbappend"
+
 # Uncomment if building curl with wolfSSL.
 #BBFILES += "${LAYERDIR}/recipes-support/curl/*.bbappend"
 
+# Uncomment if building libssh2 with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-support/libssh2/*.bbappend"
+
+# Uncomment if building net-snmp with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-protocols/net-snmp/*.bbappend"
+
 # Uncomment if building OpenSSH with wolfSSL.
 #BBFILES += "${LAYERDIR}/recipes-connectivity/openssh/*.bbappend"
+
+# Uncomment if building rsyslog with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-extended/rsyslog/*.bbappend"
+
+# Uncomment if building socat with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-connectivity/socat/*.bbappend"
+
+# Uncomment if building strongSwan with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-support/strongswan/*.bbappend"
+
+# Uncomment if building tcpdump with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-support/tcpdump/*.bbappend"
 
 BBFILE_COLLECTIONS += "wolfssl"
 BBFILE_PATTERN_wolfssl := "^${LAYERDIR}/"

--- a/recipes-connectivity/bind/bind_9.11.22.bbappend
+++ b/recipes-connectivity/bind/bind_9.11.22.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://bind-9.11.22.patch"
+DEPENDS_remove = "openssl"
+EXTRA_OECONF_remove = "--with-openssl=${STAGING_DIR_HOST}${prefix}"
+DEPENDS += " wolfssl"
+EXTRA_OECONF += " --with-wolfssl=${STAGING_EXECPREFIXDIR}"

--- a/recipes-connectivity/bind/files/bind-9.11.22.patch
+++ b/recipes-connectivity/bind/files/bind-9.11.22.patch
@@ -1,0 +1,928 @@
+From f2f5a90deed996b8f3ff66e0e70bc38b4d2f8bd1 Mon Sep 17 00:00:00 2001
+From: Juliusz Sosinowicz <juliusz@wolfssl.com>
+Date: Tue, 15 Jun 2021 17:14:31 +0200
+Subject: [PATCH] Patch for wolfSSL
+
+This patch was implemented and tested on commit 66fc6c5a9e32c9535a700cd6de5689d1ace1e4f0 of the master bind9 branch
+
+- `--with-wolfssl` configure option added. Uses `PKG_CHECK_MODULES` and `PKG_CHECK_VAR` to find the install location of the wolfSSL module.
+- `FATAL_ERROR` changed to `BIND_FATAL_ERROR` to avoid collision with wolfSSL `FATAL_ERROR`.
+- `BN_GENCB_*` not supported so uses are macro'd out.
+
+Compile wolfSSL with:
+```
+./autogen.sh
+./configure --enable-bind
+make
+make install
+```
+
+Compile bind with
+```
+patch -p1 < <path/to/this/patch>
+autoreconf -ivf
+./configure --with-wolfssl
+make
+```
+
+bind9 should pass all tests run with:
+```
+make check
+```
+If any tests fail, please first try compiling with OpenSSL to check if your system is correctly configured to run tests.
+
+Signed-off-by: Juliusz Sosinowicz <juliusz@wolfssl.com>
+---
+ bin/named/Makefile.in         |  6 ++-
+ bin/tests/optional/lex_test.c |  2 +-
+ configure.ac                  | 94 ++++++++++++++++++++++++++++++++++-
+ lib/dns/dst_openssl.h         |  8 ++-
+ lib/dns/name.c                | 10 ++--
+ lib/dns/openssl_link.c        |  3 +-
+ lib/dns/openssldh_link.c      | 23 ++++++++-
+ lib/dns/openssldsa_link.c     | 14 +++++-
+ lib/dns/opensslecdsa_link.c   |  6 ++-
+ lib/dns/opensslrsa_link.c     | 25 ++++++++++
+ lib/dns/rbtdb.c               |  2 +-
+ lib/dns/rpz.c                 |  2 +-
+ lib/isc/aes.c                 |  8 +++
+ lib/isc/include/isc/util.h    |  2 +-
+ lib/isc/lex.c                 |  2 +-
+ lib/isc/lib.c                 |  2 +-
+ lib/isc/md5.c                 |  2 +-
+ lib/isc/sha1.c                |  2 +-
+ lib/isc/sha2.c                |  8 +--
+ lib/isc/sockaddr.c            |  6 +--
+ lib/isc/unix/socket.c         |  6 +--
+ lib/isc/win32/socket.c        | 14 +++---
+ 22 files changed, 204 insertions(+), 43 deletions(-)
+
+diff --git a/bin/named/Makefile.in b/bin/named/Makefile.in
+index e7a61c9086..2065de8da9 100644
+--- a/bin/named/Makefile.in
++++ b/bin/named/Makefile.in
+@@ -155,9 +155,10 @@ named@EXEEXT@: ${OBJS} ${DEPLIBS}
+ 	export BASEOBJS="${OBJS} ${UOBJS}"; \
+ 	${FINALBUILDCMD}
+ 
++# use soft links as hard links aren't allowed on shared vm disks
+ lwresd@EXEEXT@: named@EXEEXT@
+ 	rm -f lwresd@EXEEXT@
+-	@LN@ named@EXEEXT@ lwresd@EXEEXT@
++	@LN@ named@EXEEXT@ lwresd@EXEEXT@ -s
+ 
+ doc man:: ${MANOBJS}
+ 
+@@ -180,9 +181,10 @@ installdirs:
+ 	$(SHELL) ${top_srcdir}/mkinstalldirs ${DESTDIR}${mandir}/man5
+ 	$(SHELL) ${top_srcdir}/mkinstalldirs ${DESTDIR}${mandir}/man8
+ 
++# use soft links as hard links aren't allowed on shared vm disks
+ install:: named@EXEEXT@ lwresd@EXEEXT@ installdirs
+ 	${LIBTOOL_MODE_INSTALL} ${INSTALL_PROGRAM} named@EXEEXT@ ${DESTDIR}${sbindir}
+-	(cd ${DESTDIR}${sbindir}; rm -f lwresd@EXEEXT@; @LN@ named@EXEEXT@ lwresd@EXEEXT@)
++	(cd ${DESTDIR}${sbindir}; rm -f lwresd@EXEEXT@; @LN@ named@EXEEXT@ lwresd@EXEEXT@ -s)
+ 	${INSTALL_DATA} ${srcdir}/named.8 ${DESTDIR}${mandir}/man8
+ 	${INSTALL_DATA} ${srcdir}/lwresd.8 ${DESTDIR}${mandir}/man8
+ 	${INSTALL_DATA} ${srcdir}/named.conf.5 ${DESTDIR}${mandir}/man5
+diff --git a/bin/tests/optional/lex_test.c b/bin/tests/optional/lex_test.c
+index 4631242602..5311960512 100644
+--- a/bin/tests/optional/lex_test.c
++++ b/bin/tests/optional/lex_test.c
+@@ -58,7 +58,7 @@ print_token(isc_token_t *tokenp, FILE *stream) {
+ 		fprintf(stream, "NOMORE");
+ 		break;
+ 	default:
+-		FATAL_ERROR(__FILE__, __LINE__, "Unexpected type %d",
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "Unexpected type %d",
+ 			    tokenp->type);
+ 	}
+ }
+diff --git a/configure.ac b/configure.ac
+index 33bd76ac3b..d79ccd3831 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1474,6 +1474,72 @@ AC_ARG_WITH(openssl,
+ 				(Crypto is required for DNSSEC)]),
+ 	    use_openssl="$withval", use_openssl="auto")
+ 
++#
++# was --with-wolfssl specified?
++#
++AC_ARG_WITH([wolfssl],
++	    AS_HELP_STRING([--with-wolfssl[=PATH]],
++			   [Build with wolfSSL [yes|no|path].
++				(Crypto is required for DNSSEC)]),
++	    use_wolfssl="$withval", use_wolfssl="auto")
++
++if test "no" != "$use_wolfssl"
++then
++	if test "yes" = "$use_wolfssl"
++	then
++		PKG_CHECK_MODULES(
++			[WOLFSSL],
++			[wolfssl],
++			[],
++			[AC_MSG_ERROR([Could not find wolfSSL.])]
++		)
++		PKG_CHECK_VAR(
++			[WOLFSSL_INCLUDEDIR],
++			[wolfssl],
++			[includedir],
++			[],
++			[AC_MSG_ERROR([Could not find wolfSSL includedir variable.])]
++		)
++		WOLFSSL_CFLAGS="${WOLFSSL_CFLAGS} -I${WOLFSSL_INCLUDEDIR}/wolfssl"
++	else
++		WOLFSSL_CFLAGS="${WOLFSSL_CFLAGS} -I${use_wolfssl}/include -I${use_wolfssl}/include/wolfssl"
++		WOLFSSL_LIBS="${WOLFSSL_LIBS} -L${use_wolfssl}/lib -lwolfssl"
++	fi
++	AC_DEFINE([HAVE_WOLFSSL], [1], [Use the wolfSSL TLS library])
++	WOLFSSL_CFLAGS="${WOLFSSL_CFLAGS} -DEXTERNAL_OPTS_OPENVPN"
++	AC_DEFINE([HAVE_OPENSSL_DSA], [1], [wolfSSL includes])
++	AC_DEFINE([OPENSSL_NO_ENGINE], [1], [wolfSSL includes])
++	# copied from defines that worked for version 9.17.9
++	AC_DEFINE([HAVE_ECDSA_SIGN], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_ECDSA_VERIFY], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_AES_128_ECB], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_AES_192_ECB], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_AES_256_ECB], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_CIPHER_CTX_FREE], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_CIPHER_CTX_NEW], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_MD_CTX_RESET], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_MD_CTX_FREE], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_MD_CTX_NEW], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_SHA1], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_SHA224], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_SHA256], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_SHA384], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_EVP_SHA512], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_RSA_SET0_KEY], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_TLS_SERVER_METHOD], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_HMAC_CTX_NEW], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_HMAC_CTX_FREE], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_HMAC_CTX_RESET], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_HMAC_CTX_GET_MD], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_DH_GET0_KEY], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_DSA_GET0_PQG], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_OPENSSL_EVP_AES], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_OPENSSL_AES], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_ECDSA_SIG_GET0], [1], [wolfSSL includes])
++	AC_DEFINE([HAVE_ECDSA_SIG_SET0], [1], [wolfSSL includes])
++	use_openssl="wolfssl"
++fi
++
+ #
+ # was --with-pkcs11 specified?
+ #
+@@ -1587,6 +1653,25 @@ case "$use_openssl" in
+ [OpenSSL was not found in any of $openssldirs; use --with-openssl=/path
+ If you don't want OpenSSL, use --without-openssl])
+ 		;;
++	wolfssl)
++		AC_MSG_RESULT(Using wolfSSL)
++		DST_OPENSSL_INC="${WOLFSSL_CFLAGS}"
++		DST_OPENSSL_LIBS="${WOLFSSL_LIBS}"
++		CRYPTO="-DHAVE_WOLFSSL -DOPENSSL"
++		OPENSSL_ECDSA="yes"
++		OPENSSLECDSALINKOBJS='${OPENSSLECDSALINKOBJS}'
++		OPENSSLECDSALINKSRCS='${OPENSSLECDSALINKSRCS}'
++		AC_DEFINE(HAVE_OPENSSL_ECDSA, 1,
++			  [Define if your OpenSSL version supports ECDSA.])
++		OPENSSLEDDSALINKOBJS=""
++		OPENSSLEDDSALINKSRCS=""
++		OPENSSLGOSTLINKOBJS=""
++		OPENSSLGOSTLINKSRCS=""
++		OPENSSLLINKOBJS='${OPENSSLLINKOBJS}'
++		OPENSSLLINKSRCS='${OPENSSLLINKSRCS}'
++		ISC_OPENSSL_INC="$DST_OPENSSL_INC"
++		ISC_OPENSSL_LIBS="$DST_OPENSSL_LIBS"
++		;;
+ 	*)
+ 		if test "yes" = "$want_native_pkcs11"
+ 		then
+@@ -5508,8 +5593,13 @@ report() {
+     if test "yes" = "$enable_full_report"; then
+ 	test "no" = "$enable_ipv6" -o "no" = "$found_ipv6" || \
+ 	    echo "    IPv6 support (--enable-ipv6)"
+-	test "X$CRYPTO" = "X" -o "yes" = "$want_native_pkcs11" || \
+-		echo "    OpenSSL cryptography/DNSSEC (--with-openssl)"
++	if test "no" != "$use_wolfssl"
++	then
++		echo "    wolfSSL cryptography (--with-wolfssl)"
++	else
++		test "X$CRYPTO" = "X" -o "yes" = "$want_native_pkcs11" || \
++			echo "    OpenSSL cryptography/DNSSEC (--with-openssl)"
++	fi
+ 	test "X$PYTHON" = "X" || echo "    Python tools (--with-python)"
+ 	test "X$XMLSTATS" = "X" || echo "    XML statistics (--with-libxml2)"
+ 	test "X$JSONSTATS" = "X" || echo "    JSON statistics (--with-libjson)"
+diff --git a/lib/dns/dst_openssl.h b/lib/dns/dst_openssl.h
+index e085f1132b..7cd686bfe1 100644
+--- a/lib/dns/dst_openssl.h
++++ b/lib/dns/dst_openssl.h
+@@ -32,9 +32,13 @@
+  *     	 _cb;
+  * #endif
+  */
+-#define BN_GENCB_free(x) ((void)0)
+-#define BN_GENCB_new() (&_cb)
++#define BN_GENCB_free(x)    ((void)0)
++#define BN_GENCB_new()	    (&_cb)
++#ifndef HAVE_WOLFSSL
+ #define BN_GENCB_get_arg(x) ((x)->arg)
++#else
++#define BN_GENCB_get_arg(x) (NULL)
++#endif
+ #endif
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+diff --git a/lib/dns/name.c b/lib/dns/name.c
+index 6bb213a490..f6578f4164 100644
+--- a/lib/dns/name.c
++++ b/lib/dns/name.c
+@@ -1266,7 +1266,7 @@ dns_name_fromtext(dns_name_t *name, isc_buffer_t *source,
+ 			}
+ 			break;
+ 		default:
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				    "Unexpected state %d", state);
+ 			/* Does not return. */
+ 		}
+@@ -1535,7 +1535,7 @@ dns_name_totext2(const dns_name_t *name, unsigned int options,
+ 				count--;
+ 			}
+ 		} else {
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				    "Unexpected label type %02x", count);
+ 			/* NOTREACHED */
+ 		}
+@@ -1657,7 +1657,7 @@ dns_name_tofilenametext(dns_name_t *name, bool omit_final_dot,
+ 				count--;
+ 			}
+ 		} else {
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				    "Unexpected label type %02x", count);
+ 			/* NOTREACHED */
+ 		}
+@@ -1736,7 +1736,7 @@ dns_name_downcase(dns_name_t *source, dns_name_t *name, isc_buffer_t *target) {
+ 				count--;
+ 			}
+ 		} else {
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				    "Unexpected label type %02x", count);
+ 			/* Does not return. */
+ 		}
+@@ -1938,7 +1938,7 @@ dns_name_fromwire(dns_name_t *name, isc_buffer_t *source,
+ 			state = fw_start;
+ 			break;
+ 		default:
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				    "Unknown state %d", state);
+ 			/* Does not return. */
+ 		}
+diff --git a/lib/dns/openssl_link.c b/lib/dns/openssl_link.c
+index 13e838f81f..04f42f0182 100644
+--- a/lib/dns/openssl_link.c
++++ b/lib/dns/openssl_link.c
+@@ -122,7 +122,8 @@ id_callback(void) {
+ }
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER) \
++    || defined(HAVE_WOLFSSL)
+ 
+ #define FLARG
+ #define FILELINE
+diff --git a/lib/dns/openssldh_link.c b/lib/dns/openssldh_link.c
+index 30de34316a..d35a04f059 100644
+--- a/lib/dns/openssldh_link.c
++++ b/lib/dns/openssldh_link.c
+@@ -239,6 +239,7 @@ openssldh_paramcompare(const dst_key_t *key1, const dst_key_t *key2) {
+ }
+ 
+ #if OPENSSL_VERSION_NUMBER > 0x00908000L
++#ifndef HAVE_WOLFSSL
+ static int
+ progress_cb(int p, int n, BN_GENCB *cb) {
+ 	union {
+@@ -254,11 +255,12 @@ progress_cb(int p, int n, BN_GENCB *cb) {
+ 	return (1);
+ }
+ #endif
++#endif
+ 
+ static isc_result_t
+ openssldh_generate(dst_key_t *key, int generator, void (*callback)(int)) {
+ 	DH *dh = NULL;
+-#if OPENSSL_VERSION_NUMBER > 0x00908000L
++#if OPENSSL_VERSION_NUMBER > 0x00908000L && !defined(HAVE_WOLFSSL)
+ 	BN_GENCB *cb;
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	BN_GENCB _cb;
+@@ -305,22 +307,32 @@ openssldh_generate(dst_key_t *key, int generator, void (*callback)(int)) {
+ 		dh = DH_new();
+ 		if (dh == NULL)
+ 			return (dst__openssl_toresult(ISC_R_NOMEMORY));
++#ifndef HAVE_WOLFSSL
+ 		cb = BN_GENCB_new();
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#endif
++#endif
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(HAVE_WOLFSSL)
+ 		if (cb == NULL) {
+ 			DH_free(dh);
+ 			return (dst__openssl_toresult(ISC_R_NOMEMORY));
+ 		}
+ #endif
++
++#ifndef HAVE_WOLFSSL
+ 		if (callback == NULL) {
+ 			BN_GENCB_set_old(cb, NULL, NULL);
+ 		} else {
+ 			u.fptr = callback;
+ 			BN_GENCB_set(cb, &progress_cb, u.dptr);
+ 		}
++#endif
+ 
+ 		if (!DH_generate_parameters_ex(dh, key->key_size, generator,
++#ifndef HAVE_WOLFSSL
+ 					       cb)) {
++#else
++					       NULL)) {
++#endif
+ 			DH_free(dh);
+ 			BN_GENCB_free(cb);
+ 			return (dst__openssl_toresult2(
+@@ -328,6 +340,7 @@ openssldh_generate(dst_key_t *key, int generator, void (*callback)(int)) {
+ 					DST_R_OPENSSLFAILURE));
+ 		}
+ 		BN_GENCB_free(cb);
++#ifndef HAVE_WOLFSSL
+ 		cb = NULL;
+ #else
+ 		dh = DH_generate_parameters(key->key_size, generator,
+@@ -344,7 +357,9 @@ openssldh_generate(dst_key_t *key, int generator, void (*callback)(int)) {
+ 		return (dst__openssl_toresult2("DH_generate_key",
+ 					       DST_R_OPENSSLFAILURE));
+ 	}
++#ifndef HAVE_WOLFSSL
+ 	DH_clear_flags(dh, DH_FLAG_CACHE_MONT_P);
++#endif
+ 	key->keydata.dh = dh;
+ 
+ 	return (ISC_R_SUCCESS);
+@@ -463,7 +478,9 @@ openssldh_fromdns(dst_key_t *key, isc_buffer_t *data) {
+ 	dh = DH_new();
+ 	if (dh == NULL)
+ 		return (dst__openssl_toresult(ISC_R_NOMEMORY));
++#ifndef HAVE_WOLFSSL
+ 	DH_clear_flags(dh, DH_FLAG_CACHE_MONT_P);
++#endif
+ 
+ 	/*
+ 	 * Read the prime length.  1 & 2 are table entries, > 16 means a
+@@ -675,7 +692,9 @@ openssldh_parse(dst_key_t *key, isc_lex_t *lexer, dst_key_t *pub) {
+ 	dh = DH_new();
+ 	if (dh == NULL)
+ 		DST_RET(ISC_R_NOMEMORY);
++#ifndef HAVE_WOLFSSL
+ 	DH_clear_flags(dh, DH_FLAG_CACHE_MONT_P);
++#endif
+ 	key->keydata.dh = dh;
+ 
+ 	for (i = 0; i < priv.nelements; i++) {
+diff --git a/lib/dns/openssldsa_link.c b/lib/dns/openssldsa_link.c
+index 8abf4bb02d..bd79c2bdd0 100644
+--- a/lib/dns/openssldsa_link.c
++++ b/lib/dns/openssldsa_link.c
+@@ -122,7 +122,9 @@ DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
+ }
+ 
+ 
++#ifndef HAVE_WOLFSSL
+ #define DSA_clear_flags(d, x) (d)->flags &= ~(x)
++#endif
+ 
+ #endif
+ 
+@@ -418,6 +420,7 @@ openssldsa_compare(const dst_key_t *key1, const dst_key_t *key2) {
+ }
+ 
+ #if OPENSSL_VERSION_NUMBER > 0x00908000L
++#ifndef HAVE_WOLFSSL
+ static int
+ progress_cb(int p, int n, BN_GENCB *cb) {
+ 	union {
+@@ -433,13 +436,14 @@ progress_cb(int p, int n, BN_GENCB *cb) {
+ 	return (1);
+ }
+ #endif
++#endif
+ 
+ static isc_result_t
+ openssldsa_generate(dst_key_t *key, int unused, void (*callback)(int)) {
+ 	DSA *dsa;
+ 	unsigned char rand_array[ISC_SHA1_DIGESTLENGTH];
+ 	isc_result_t result;
+-#if OPENSSL_VERSION_NUMBER > 0x00908000L
++#if OPENSSL_VERSION_NUMBER > 0x00908000L && !defined(HAVE_WOLFSSL)
+ 	BN_GENCB *cb;
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	BN_GENCB _cb;
+@@ -460,7 +464,7 @@ openssldsa_generate(dst_key_t *key, int unused, void (*callback)(int)) {
+ 	if (result != ISC_R_SUCCESS)
+ 		return (result);
+ 
+-#if OPENSSL_VERSION_NUMBER > 0x00908000L
++#if OPENSSL_VERSION_NUMBER > 0x00908000L && !defined(HAVE_WOLFSSL)
+ 	dsa = DSA_new();
+ 	if (dsa == NULL)
+ 		return (dst__openssl_toresult(DST_R_OPENSSLFAILURE));
+@@ -504,7 +508,9 @@ openssldsa_generate(dst_key_t *key, int unused, void (*callback)(int)) {
+ 					       DST_R_OPENSSLFAILURE));
+ 	}
+ 
++#ifndef HAVE_WOLFSSL
+ 	DSA_clear_flags(dsa, DSA_FLAG_CACHE_MONT_P);
++#endif
+ 
+ 	key->keydata.dsa = dsa;
+ 
+@@ -588,7 +594,9 @@ openssldsa_fromdns(dst_key_t *key, isc_buffer_t *data) {
+ 	dsa = DSA_new();
+ 	if (dsa == NULL)
+ 		return (ISC_R_NOMEMORY);
++#ifndef HAVE_WOLFSSL
+ 	DSA_clear_flags(dsa, DSA_FLAG_CACHE_MONT_P);
++#endif
+ 
+ 	t = (unsigned int) *r.base;
+ 	isc_region_consume(&r, 1);
+@@ -724,7 +732,9 @@ openssldsa_parse(dst_key_t *key, isc_lex_t *lexer, dst_key_t *pub) {
+ 	dsa = DSA_new();
+ 	if (dsa == NULL)
+ 		DST_RET(ISC_R_NOMEMORY);
++#ifndef HAVE_WOLFSSL
+ 	DSA_clear_flags(dsa, DSA_FLAG_CACHE_MONT_P);
++#endif
+ 	key->keydata.dsa = dsa;
+ 
+ 	for (i = 0; i < priv.nelements; i++) {
+diff --git a/lib/dns/opensslecdsa_link.c b/lib/dns/opensslecdsa_link.c
+index e9ea5eada6..56b9a93a82 100644
+--- a/lib/dns/opensslecdsa_link.c
++++ b/lib/dns/opensslecdsa_link.c
+@@ -39,12 +39,14 @@
+ #include <openssl/ecdsa.h>
+ #include <openssl/bn.h>
+ 
++#ifndef HAVE_WOLFSSL
+ #ifndef NID_X9_62_prime256v1
+ #error "P-256 group is not known (NID_X9_62_prime256v1)"
+ #endif
+ #ifndef NID_secp384r1
+ #error "P-384 group is not known (NID_secp384r1)"
+ #endif
++#endif
+ 
+ #define DST_RET(a) {ret = a; goto err;}
+ 
+@@ -506,10 +508,10 @@ opensslecdsa_tofile(const dst_key_t *key, const char *directory) {
+ 	ret = dst__privstruct_writefile(key, &priv, directory);
+ 
+  err:
+-	if (eckey != NULL)
+-		EC_KEY_free(eckey);
+ 	if (buf != NULL)
+ 		isc_mem_put(key->mctx, buf, BN_num_bytes(privkey));
++	if (eckey != NULL)
++		EC_KEY_free(eckey);
+ 	return (ret);
+ }
+ 
+diff --git a/lib/dns/opensslrsa_link.c b/lib/dns/opensslrsa_link.c
+index 473ea0d9bc..3bf8dc1ca5 100644
+--- a/lib/dns/opensslrsa_link.c
++++ b/lib/dns/opensslrsa_link.c
+@@ -972,6 +972,7 @@ opensslrsa_compare(const dst_key_t *key1, const dst_key_t *key2) {
+ }
+ 
+ #if OPENSSL_VERSION_NUMBER > 0x00908000L
++#ifndef HAVE_WOLFSSL
+ static int
+ progress_cb(int p, int n, BN_GENCB *cb) {
+ 	union {
+@@ -987,6 +988,7 @@ progress_cb(int p, int n, BN_GENCB *cb) {
+ 	return (1);
+ }
+ #endif
++#endif
+ 
+ static isc_result_t
+ opensslrsa_generate(dst_key_t *key, int exp, void (*callback)(int)) {
+@@ -998,10 +1000,15 @@ opensslrsa_generate(dst_key_t *key, int exp, void (*callback)(int)) {
+ 	} u;
+ 	RSA *rsa = RSA_new();
+ 	BIGNUM *e = BN_new();
++#ifndef HAVE_WOLFSSL
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	BN_GENCB _cb;
+ #endif
+ 	BN_GENCB *cb = BN_GENCB_new();
++#else
++	UNUSED(callback);
++	UNUSED(u);
++#endif
+ #if USE_EVP
+ 	EVP_PKEY *pkey = EVP_PKEY_new();
+ #endif
+@@ -1034,7 +1041,11 @@ opensslrsa_generate(dst_key_t *key, int exp, void (*callback)(int)) {
+ 		ISC_UNREACHABLE();
+ 	}
+ 
++#ifndef HAVE_WOLFSSL
+ 	if (rsa == NULL || e == NULL || cb == NULL)
++#else
++	if (rsa == NULL || e == NULL)
++#endif
+ 		goto err;
+ #if USE_EVP
+ 	if (pkey == NULL)
+@@ -1053,6 +1064,7 @@ opensslrsa_generate(dst_key_t *key, int exp, void (*callback)(int)) {
+ 		BN_set_bit(e, 32);
+ 	}
+ 
++#ifndef HAVE_WOLFSSL
+ 	if (callback == NULL) {
+ 		BN_GENCB_set_old(cb, NULL, NULL);
+ 	} else {
+@@ -1061,9 +1073,14 @@ opensslrsa_generate(dst_key_t *key, int exp, void (*callback)(int)) {
+ 	}
+ 
+ 	if (RSA_generate_key_ex(rsa, key->key_size, e, cb)) {
++#else
++	if (RSA_generate_key_ex(rsa, key->key_size, e, NULL)) {
++#endif
+ 		BN_free(e);
++#ifndef HAVE_WOLFSSL
+ 		BN_GENCB_free(cb);
+ 		cb = NULL;
++#endif
+ 		SET_FLAGS(rsa);
+ #if USE_EVP
+ 		key->keydata.pkey = pkey;
+@@ -1092,10 +1109,12 @@ opensslrsa_generate(dst_key_t *key, int exp, void (*callback)(int)) {
+ 		RSA_free(rsa);
+ 		rsa = NULL;
+ 	}
++#ifndef HAVE_WOLFSSL
+ 	if (cb != NULL) {
+ 		BN_GENCB_free(cb);
+ 		cb = NULL;
+ 	}
++#endif
+ 	return (dst__openssl_toresult(ret));
+ #else
+ 	RSA *rsa;
+@@ -1495,7 +1514,11 @@ opensslrsa_parse(dst_key_t *key, isc_lex_t *lexer, dst_key_t *pub) {
+ 	const BIGNUM *ex = NULL;
+ #endif
+ 	isc_mem_t *mctx = key->mctx;
++#ifndef HAVE_WOLFSSL
+ 	const char *engine = NULL, *label = NULL;
++#else
++	const char *label = NULL;
++#endif
+ #if !defined(OPENSSL_NO_ENGINE) || USE_EVP
+ 	EVP_PKEY *pkey = NULL;
+ #endif
+@@ -1533,9 +1556,11 @@ opensslrsa_parse(dst_key_t *key, isc_lex_t *lexer, dst_key_t *pub) {
+ 
+ 	for (i = 0; i < priv.nelements; i++) {
+ 		switch (priv.elements[i].tag) {
++#ifndef HAVE_WOLFSSL
+ 		case TAG_RSA_ENGINE:
+ 			engine = (char *)priv.elements[i].data;
+ 			break;
++#endif
+ 		case TAG_RSA_LABEL:
+ 			label = (char *)priv.elements[i].data;
+ 			break;
+diff --git a/lib/dns/rbtdb.c b/lib/dns/rbtdb.c
+index baf764174a..dde5d61ecb 100644
+--- a/lib/dns/rbtdb.c
++++ b/lib/dns/rbtdb.c
+@@ -4657,7 +4657,7 @@ zone_findzonecut(dns_db_t *db, dns_name_t *name, unsigned int options,
+ 	UNUSED(rdataset);
+ 	UNUSED(sigrdataset);
+ 
+-	FATAL_ERROR(__FILE__, __LINE__, "zone_findzonecut() called!");
++	BIND_FATAL_ERROR(__FILE__, __LINE__, "zone_findzonecut() called!");
+ 
+ 	/* NOTREACHED */
+ 	return (ISC_R_NOTIMPLEMENTED);
+diff --git a/lib/dns/rpz.c b/lib/dns/rpz.c
+index b98749996d..aafdfdcaff 100644
+--- a/lib/dns/rpz.c
++++ b/lib/dns/rpz.c
+@@ -185,7 +185,7 @@ dns_rpz_type2str(dns_rpz_type_t type) {
+ 	case DNS_RPZ_TYPE_BAD:
+ 		break;
+ 	}
+-	FATAL_ERROR(__FILE__, __LINE__, "impossible rpz type %d", type);
++	BIND_FATAL_ERROR(__FILE__, __LINE__, "impossible rpz type %d", type);
+ 	return ("impossible");
+ }
+ 
+diff --git a/lib/isc/aes.c b/lib/isc/aes.c
+index 2ca07f6a4b..23060202a2 100644
+--- a/lib/isc/aes.c
++++ b/lib/isc/aes.c
+@@ -27,17 +27,21 @@
+ #include <openssl/opensslv.h>
+ #include <openssl/evp.h>
+ 
++#ifndef HAVE_WOLFSSL
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define EVP_CIPHER_CTX_new() &(_context), EVP_CIPHER_CTX_init(&_context)
+ #define EVP_CIPHER_CTX_free(c) RUNTIME_CHECK(EVP_CIPHER_CTX_cleanup(c) == 1)
+ #endif
++#endif
+ 
+ void
+ isc_aes128_crypt(const unsigned char *key, const unsigned char *in,
+ 		 unsigned char *out)
+ {
++#ifndef HAVE_WOLFSSL
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	EVP_CIPHER_CTX _context;
++#endif
+ #endif
+ 	EVP_CIPHER_CTX *c;
+ 	int len;
+@@ -56,8 +60,10 @@ void
+ isc_aes192_crypt(const unsigned char *key, const unsigned char *in,
+ 		 unsigned char *out)
+ {
++#ifndef HAVE_WOLFSSL
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	EVP_CIPHER_CTX _context;
++#endif
+ #endif
+ 	EVP_CIPHER_CTX *c;
+ 	int len;
+@@ -76,8 +82,10 @@ void
+ isc_aes256_crypt(const unsigned char *key, const unsigned char *in,
+ 		 unsigned char *out)
+ {
++#ifndef HAVE_WOLFSSL
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	EVP_CIPHER_CTX _context;
++#endif
+ #endif
+ 	EVP_CIPHER_CTX *c;
+ 	int len;
+diff --git a/lib/isc/include/isc/util.h b/lib/isc/include/isc/util.h
+index 98101c981e..dcdff558e7 100644
+--- a/lib/isc/include/isc/util.h
++++ b/lib/isc/include/isc/util.h
+@@ -289,7 +289,7 @@ extern void mock_assert(const int result, const char* const expression,
+ /*% Unexpected Error */
+ #define UNEXPECTED_ERROR		isc_error_unexpected
+ /*% Fatal Error */
+-#define FATAL_ERROR			isc_error_fatal
++#define BIND_FATAL_ERROR			isc_error_fatal
+ 
+ #ifdef UNIT_TESTING
+ 
+diff --git a/lib/isc/lex.c b/lib/isc/lex.c
+index 9c384fd5e6..8e9735ccc5 100644
+--- a/lib/isc/lex.c
++++ b/lib/isc/lex.c
+@@ -853,7 +853,7 @@ isc_lex_gettoken(isc_lex_t *lex, unsigned int options, isc_token_t *tokenp) {
+ 			remaining--;
+ 			break;
+ 		default:
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				    isc_msgcat_get(isc_msgcat, ISC_MSGSET_LEX,
+ 						   ISC_MSG_UNEXPECTEDSTATE,
+ 						   "Unexpected state %d"),
+diff --git a/lib/isc/lib.c b/lib/isc/lib.c
+index 018cc3e8aa..4acada85ab 100644
+--- a/lib/isc/lib.c
++++ b/lib/isc/lib.c
+@@ -62,7 +62,7 @@ isc_lib_initmsgcat(void) {
+ 	result = isc_once_do(&msgcat_once, open_msgcat);
+ 	if (result != ISC_R_SUCCESS) {
+ 		/*
+-		 * Normally we'd use RUNTIME_CHECK() or FATAL_ERROR(), but
++		 * Normally we'd use RUNTIME_CHECK() or BIND_FATAL_ERROR(), but
+ 		 * we can't do that here, since they might call us!
+ 		 * (Note that the catalog might be open anyway, so we might
+ 		 * as well try to  provide an internationalized message.)
+diff --git a/lib/isc/md5.c b/lib/isc/md5.c
+index 249f3da2f2..09963574ca 100644
+--- a/lib/isc/md5.c
++++ b/lib/isc/md5.c
+@@ -59,7 +59,7 @@ isc_md5_init(isc_md5_t *ctx) {
+ 	ctx->ctx = EVP_MD_CTX_new();
+ 	RUNTIME_CHECK(ctx->ctx != NULL);
+ 	if (EVP_DigestInit(ctx->ctx, EVP_md5()) != 1) {
+-		FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize MD5.");
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize MD5.");
+ 	}
+ }
+ 
+diff --git a/lib/isc/sha1.c b/lib/isc/sha1.c
+index 4f133c6d40..b678cb765e 100644
+--- a/lib/isc/sha1.c
++++ b/lib/isc/sha1.c
+@@ -60,7 +60,7 @@ isc_sha1_init(isc_sha1_t *context)
+ 	context->ctx = EVP_MD_CTX_new();
+ 	RUNTIME_CHECK(context->ctx != NULL);
+ 	if (EVP_DigestInit(context->ctx, EVP_sha1()) != 1) {
+-		FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA1.");
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA1.");
+ 	}
+ }
+ 
+diff --git a/lib/isc/sha2.c b/lib/isc/sha2.c
+index 8e502bfec2..d914eae3d4 100644
+--- a/lib/isc/sha2.c
++++ b/lib/isc/sha2.c
+@@ -81,7 +81,7 @@ isc_sha224_init(isc_sha224_t *context) {
+ 	context->ctx = EVP_MD_CTX_new();
+ 	RUNTIME_CHECK(context->ctx != NULL);
+ 	if (EVP_DigestInit(context->ctx, EVP_sha224()) != 1) {
+-		FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA224.");
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA224.");
+ 	}
+ }
+ 
+@@ -129,7 +129,7 @@ isc_sha256_init(isc_sha256_t *context) {
+ 	context->ctx = EVP_MD_CTX_new();
+ 	RUNTIME_CHECK(context->ctx != NULL);
+ 	if (EVP_DigestInit(context->ctx, EVP_sha256()) != 1) {
+-		FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA256.");
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA256.");
+ 	}
+ }
+ 
+@@ -177,7 +177,7 @@ isc_sha512_init(isc_sha512_t *context) {
+ 	context->ctx = EVP_MD_CTX_new();
+ 	RUNTIME_CHECK(context->ctx != NULL);
+ 	if (EVP_DigestInit(context->ctx, EVP_sha512()) != 1) {
+-		FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA512.");
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA512.");
+ 	}
+ }
+ 
+@@ -223,7 +223,7 @@ isc_sha384_init(isc_sha384_t *context) {
+ 	context->ctx = EVP_MD_CTX_new();
+ 	RUNTIME_CHECK(context->ctx != NULL);
+ 	if (EVP_DigestInit(context->ctx, EVP_sha384()) != 1) {
+-		FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA384.");
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "Cannot initialize SHA384.");
+ 	}
+ }
+ 
+diff --git a/lib/isc/sockaddr.c b/lib/isc/sockaddr.c
+index c2c599e1a6..1716dd5a5f 100644
+--- a/lib/isc/sockaddr.c
++++ b/lib/isc/sockaddr.c
+@@ -348,7 +348,7 @@ isc_sockaddr_pf(const isc_sockaddr_t *sockaddr) {
+ 	case AF_INET6:
+ 		return (PF_INET6);
+ 	default:
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKADDR,
+ 					   ISC_MSG_UNKNOWNFAMILY,
+ 					   "unknown address family: %d"),
+@@ -400,7 +400,7 @@ isc_sockaddr_setport(isc_sockaddr_t *sockaddr, in_port_t port) {
+ 		sockaddr->type.sin6.sin6_port = htons(port);
+ 		break;
+ 	default:
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKADDR,
+ 					   ISC_MSG_UNKNOWNFAMILY,
+ 					   "unknown address family: %d"),
+@@ -420,7 +420,7 @@ isc_sockaddr_getport(const isc_sockaddr_t *sockaddr) {
+ 		port = ntohs(sockaddr->type.sin6.sin6_port);
+ 		break;
+ 	default:
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKADDR,
+ 					   ISC_MSG_UNKNOWNFAMILY,
+ 					   "unknown address family: %d"),
+diff --git a/lib/isc/unix/socket.c b/lib/isc/unix/socket.c
+index d250a6f1fd..b37b85baa1 100644
+--- a/lib/isc/unix/socket.c
++++ b/lib/isc/unix/socket.c
+@@ -1200,7 +1200,7 @@ select_poke(isc__socketmgr_t *mgr, int fd, int msg) {
+ 
+ 	if (cc < 0) {
+ 		isc__strerror(errno, strbuf, sizeof(strbuf));
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 					   ISC_MSG_WRITEFAILED,
+ 					   "write() failed "
+@@ -1228,7 +1228,7 @@ select_readmsg(isc__socketmgr_t *mgr, int *fd, int *msg) {
+ 			return;
+ 
+ 		isc__strerror(errno, strbuf, sizeof(strbuf));
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 					   ISC_MSG_READFAILED,
+ 					   "read() failed "
+@@ -4356,7 +4356,7 @@ watcher(void *uap) {
+ 
+ 			if (cc < 0 && !SOFT_ERROR(errno)) {
+ 				isc__strerror(errno, strbuf, sizeof(strbuf));
+-				FATAL_ERROR(__FILE__, __LINE__,
++				BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 					    "%s %s: %s", fnname,
+ 					    isc_msgcat_get(isc_msgcat,
+ 							   ISC_MSGSET_GENERAL,
+diff --git a/lib/isc/win32/socket.c b/lib/isc/win32/socket.c
+index 5d3c3bd219..5d9a7adc50 100644
+--- a/lib/isc/win32/socket.c
++++ b/lib/isc/win32/socket.c
+@@ -465,7 +465,7 @@ signal_iocompletionport_exit(isc_socketmgr_t *manager) {
+ 						0, 0, 0)) {
+ 			errval = GetLastError();
+ 			isc__strerror(errval, strbuf, sizeof(strbuf));
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 				ISC_MSG_FAILED,
+ 				"Can't request service thread to exit: %s"),
+@@ -495,7 +495,7 @@ iocompletionport_createthreads(int total_threads, isc_socketmgr_t *manager) {
+ 		if (manager->hIOCPThreads[i] == NULL) {
+ 			errval = GetLastError();
+ 			isc__strerror(errval, strbuf, sizeof(strbuf));
+-			FATAL_ERROR(__FILE__, __LINE__,
++			BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 				ISC_MSG_FAILED,
+ 				"Can't create IOCP thread: %s"),
+@@ -521,7 +521,7 @@ iocompletionport_init(isc_socketmgr_t *manager) {
+ 	if (hHeapHandle == NULL) {
+ 		errval = GetLastError();
+ 		isc__strerror(errval, strbuf, sizeof(strbuf));
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 					   ISC_MSG_FAILED,
+ 					   "HeapCreate() failed during "
+@@ -538,7 +538,7 @@ iocompletionport_init(isc_socketmgr_t *manager) {
+ 	if (manager->hIoCompletionPort == NULL) {
+ 		errval = GetLastError();
+ 		isc__strerror(errval, strbuf, sizeof(strbuf));
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 				ISC_MSG_FAILED,
+ 				"CreateIoCompletionPort() failed "
+@@ -582,7 +582,7 @@ iocompletionport_update(isc_socket_t *sock) {
+ 		 * This function should return errors to the caller, not
+ 		 * exit here.
+ 		 */
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 				ISC_MSG_FAILED,
+ 				"CreateIoCompletionPort() failed "
+@@ -635,7 +635,7 @@ initialise(void) {
+ 	if (err != 0) {
+ 		char strbuf[ISC_STRERRORSIZE];
+ 		isc__strerror(err, strbuf, sizeof(strbuf));
+-		FATAL_ERROR(__FILE__, __LINE__, "WSAStartup() %s: %s",
++		BIND_FATAL_ERROR(__FILE__, __LINE__, "WSAStartup() %s: %s",
+ 			    isc_msgcat_get(isc_msgcat, ISC_MSGSET_GENERAL,
+ 					   ISC_MSG_FAILED, "failed"),
+ 			    strbuf);
+@@ -2519,7 +2519,7 @@ SocketIoThread(LPVOID ThreadContext) {
+ 			       THREAD_PRIORITY_ABOVE_NORMAL)) {
+ 		errval = GetLastError();
+ 		isc__strerror(errval, strbuf, sizeof(strbuf));
+-		FATAL_ERROR(__FILE__, __LINE__,
++		BIND_FATAL_ERROR(__FILE__, __LINE__,
+ 				isc_msgcat_get(isc_msgcat, ISC_MSGSET_SOCKET,
+ 				ISC_MSG_FAILED,
+ 				"Can't set thread priority: %s"),
+-- 
+2.25.1
+

--- a/recipes-connectivity/bind/wolfssl_%.bbappend
+++ b/recipes-connectivity/bind/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-bind"

--- a/recipes-connectivity/openssh/files/openssh-8.5p1.patch
+++ b/recipes-connectivity/openssh/files/openssh-8.5p1.patch
@@ -1,8 +1,8 @@
 diff --git a/cipher.c b/cipher.c
-index 639511cf..d528d01f 100644
+index 639511cf..7950a105 100644
 --- a/cipher.c
 +++ b/cipher.c
-@@ -392,10 +392,16 @@ cipher_crypt(struct sshcipher_ctx *cc, u_int seqnr, u_char *dest,
+@@ -392,10 +392,19 @@ cipher_crypt(struct sshcipher_ctx *cc, u_int seqnr, u_char *dest,
  	    len) < 0)
  		return SSH_ERR_LIBCRYPTO_ERROR;
  	if (authlen) {
@@ -10,16 +10,19 @@ index 639511cf..d528d01f 100644
 +		 * EVP_Cipher call. Note that if the tag was bad on decryption, the
 +		 * error with wolfSSL will be SSH_ERR_LIBCRYPTO_ERROR rather than
 +		 * SSH_ERR_MAC_INVALID .*/
-+	#ifndef USING_WOLFSSL
++
  		/* compute tag (on encrypt) or verify tag (on decrypt) */
  		if (EVP_Cipher(cc->evp, NULL, NULL, 0) < 0)
++	#ifndef USING_WOLFSSL
  			return cc->encrypt ?
  			    SSH_ERR_LIBCRYPTO_ERROR : SSH_ERR_MAC_INVALID;
++	#else
++			return SSH_ERR_LIBCRYPTO_ERROR;
 +	#endif
  		if (cc->encrypt &&
  		    !EVP_CIPHER_CTX_ctrl(cc->evp, EVP_CTRL_GCM_GET_TAG,
  		    authlen, dest + aadlen + len))
-@@ -532,7 +538,11 @@ cipher_set_keyiv(struct sshcipher_ctx *cc, const u_char *iv, size_t len)
+@@ -532,7 +541,11 @@ cipher_set_keyiv(struct sshcipher_ctx *cc, const u_char *iv, size_t len)
  		if (!EVP_CIPHER_CTX_ctrl(cc->evp,
  		    EVP_CTRL_GCM_SET_IV_FIXED, -1, (void *)iv))
  			return SSH_ERR_LIBCRYPTO_ERROR;
@@ -423,6 +426,39 @@ index 724974b7..d6b173c6 100644
  }
  
  struct fwdarg {
+diff --git a/regress/integrity.sh b/regress/integrity.sh
+index bc030cb7..90dd05d4 100644
+--- a/regress/integrity.sh
++++ b/regress/integrity.sh
+@@ -28,6 +28,12 @@ for m in $macs; do
+ 	etmo=0
+ 	ecnt=0
+ 	skip=0
++	gcm=0
++
++	if echo "$m" | grep -q "gcm"; then
++		gcm=1
++	fi
++
+ 	for off in `jot $tries $startoffset`; do
+ 		skip=`expr $skip - 1`
+ 		if [ $skip -gt 0 ]; then
+@@ -59,6 +65,15 @@ for m in $macs; do
+ 		Bad?packet*)	elen=`expr $elen + 1`; skip=3;;
+ 		Corrupted?MAC* | *message?authentication?code?incorrect*)
+ 				emac=`expr $emac + 1`; skip=0;;
++		# With wolfSSL, a MAC error looks like a generic libcrypto error. See
++		# comments in cipher.c.
++		*error?in?libcrypto*)
++			if [ "$gcm" = 1 ]; then
++				emac=`expr $emac + 1`; skip=0
++			else
++				fail "unexpected error mac $m at $off: $out"
++			fi
++		;;
+ 		padding*)	epad=`expr $epad + 1`; skip=0;;
+ 		*Timeout,?server*)
+ 				etmo=`expr $etmo + 1`; skip=0;;
 diff --git a/regress/misc/sk-dummy/sk-dummy.c b/regress/misc/sk-dummy/sk-dummy.c
 index 4003362d..fe541212 100644
 --- a/regress/misc/sk-dummy/sk-dummy.c

--- a/recipes-connectivity/socat/files/socat-1.7.3.4.patch
+++ b/recipes-connectivity/socat/files/socat-1.7.3.4.patch
@@ -1,0 +1,776 @@
+diff --git a/config.h.in b/config.h.in
+index 17a6549..d60b9c7 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -633,6 +633,8 @@
+ #undef WITH_EXT2
+ #undef WITH_OPENSSL
+ #undef WITH_OPENSSL_METHOD
++#undef WITH_WOLFSSL
++#undef OPENSSL_NO_COMP
+ #undef WITH_RES_DEPRECATED 	/* AAONLY,PRIMARY */
+ #define WITH_STREAMS 1
+ #undef WITH_FIPS
+diff --git a/configure.ac b/configure.ac
+index d788dc1..3d33bc4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -474,108 +474,175 @@ if test -n "$WITH_READLINE"; then
+   fi
+ fi
+ 
+-AC_MSG_CHECKING(whether to include openssl support)
+-AC_ARG_ENABLE(openssl, [  --disable-openssl       disable OpenSSL support],
+-  [ case "$enableval" in
+-    no) AC_MSG_RESULT(no); WITH_OPENSSL= ;;
+-    *) AC_MSG_RESULT(yes); WITH_OPENSSL=1 ;;
+-   esac],
+-   [ AC_MSG_RESULT(yes);   WITH_OPENSSL=1 ])
+-#
+-if test -n "$WITH_OPENSSL"; then
+-  AC_MSG_NOTICE(checking for components of OpenSSL)
+-  # first, we need to find the include file <openssl/ssl.h>
+-  AC_CACHE_VAL(sc_cv_have_openssl_ssl_h,
+-    [AC_TRY_COMPILE([#include <openssl/ssl.h>],[;],
+-      [sc_cv_have_openssl_ssl_h=yes; OPENSSL_ROOT=""; ],
+-      [sc_cv_have_openssl_ssl_h=no
+-       for D in "/sw" "/usr/local" "/opt/freeware" "/usr/sfw" "/usr/local/ssl"; do
+-	I="$D/include"
+-	i="$I/openssl/ssl.h"
+-	if test -r "$i"; then
+-	  #V_INCL="$V_INCL -I$I"
+-	  CPPFLAGS="$CPPFLAGS -I$I"
+-	  AC_MSG_NOTICE(found $i)
+-	  sc_cv_have_openssl_ssl_h=yes; OPENSSL_ROOT="$D"
+-	  break;
++AC_MSG_CHECKING(whether to include wolfSSL support)
++WOLFSSL_URL="https://www.wolfssl.com/download/"
++AC_ARG_WITH(wolfssl,
++    [  --with-wolfssl=PATH     PATH to wolfssl install (default /usr/local) ],
++    [
++        if test "x$withval" != "xno"; then
++           if test -d "$withval/lib"; then
++                LDFLAGS="-L${withval}/lib ${LDFLAGS}"
++           fi
++           if test -d "$withval/include"; then
++               CPPFLAGS="$CPPFLAGS -I${withval}/include -I${withval}/include/wolfssl"
++           fi
++        fi
++
++        if test "x$withval" == "xyes" ; then
++            LDFLAGS="-L/usr/local/lib $LDFLAGS"
++            CPPFLAGS="-I/usr/local/include -I/usr/local/include/wolfssl $CPPFLAGS"
++        fi
++
++        LIBS="$LIBS -lwolfssl"
++
++        AC_MSG_RESULT([yes])
++
++        AC_DEFINE([WITH_WOLFSSL])
++        AC_DEFINE([WITH_OPENSSL])
++        AC_DEFINE([WITH_OPENSSL_METHOD])
++
++        # Note that we are disabling compression when using wolfSSL.
++        AC_DEFINE([OPENSSL_NO_COMP])
++
++        AC_CHECK_FUNC([wolfTLS_client_method],     [AC_DEFINE([HAVE_TLS_client_method])], [])
++        AC_CHECK_FUNC([wolfTLS_server_method],     [AC_DEFINE([HAVE_TLS_server_method])], [])
++        AC_CHECK_FUNC([wolfSSLv2_client_method],   [AC_DEFINE([HAVE_SSLv2_client_method])], [])
++        AC_CHECK_FUNC([wolfSSLv2_server_method],   [AC_DEFINE([HAVE_SSLv2_server_method])], [])
++        AC_CHECK_FUNC([wolfSSLv3_client_method],   [AC_DEFINE([HAVE_SSLv3_client_method])], [])
++        AC_CHECK_FUNC([wolfSSLv3_server_method],   [AC_DEFINE([HAVE_SSLv3_server_method])], [])
++        AC_CHECK_FUNC([wolfSSLv23_client_method],  [AC_DEFINE([HAVE_SSLv23_client_method])], [])
++        AC_CHECK_FUNC([wolfSSLv23_server_method],  [AC_DEFINE([HAVE_SSLv23_server_method])], [])
++        AC_CHECK_FUNC([wolfTLSv1_client_method],   [AC_DEFINE([HAVE_TLSv1_client_method])], [])
++        AC_CHECK_FUNC([wolfTLSv1_server_method],   [AC_DEFINE([HAVE_TLSv1_server_method])], [])
++        AC_CHECK_FUNC([wolfTLSv1_1_client_method], [AC_DEFINE([HAVE_TLSv1_1_client_method])], [])
++        AC_CHECK_FUNC([wolfTLSv1_1_server_method], [AC_DEFINE([HAVE_TLSv1_1_server_method])], [])
++        AC_CHECK_FUNC([wolfTLSv1_2_client_method], [AC_DEFINE([HAVE_TLSv1_2_client_method])], [])
++        AC_CHECK_FUNC([wolfTLSv1_2_server_method], [AC_DEFINE([HAVE_TLSv1_2_server_method])], [])
++        AC_CHECK_FUNC([wolfDTLSv1_client_method],  [AC_DEFINE([HAVE_DTLSv1_client_method])], [])
++        AC_CHECK_FUNC([wolfDTLSv1_server_method],  [AC_DEFINE([HAVE_DTLSv1_server_method])], [])
++        AC_CHECK_FUNC([wolfSSL_RAND_egd],          [AC_DEFINE([HAVE_RAND_egd])], [])
++        AC_CHECK_FUNC([wolfSSL_DH_set0_pqg],       [AC_DEFINE([HAVE_DH_set0_pqg])], [])
++        AC_CHECK_FUNC([wolfSSL_ASN1_STRING_data],  [AC_DEFINE([HAVE_ASN1_STRING_get0_data])], [])
++        AC_CHECK_FUNC([wolfSSL_RAND_status],       [AC_DEFINE([HAVE_RAND_status])], [])
++
++        AC_MSG_CHECKING(for type WOLFSSL_EC_KEY)
++        AC_TRY_COMPILE([#include <wolfssl/openssl/ec.h>], [EC_KEY *s;], [HAVE_TYPE_EC_KEY=yes], [HAVE_TYPE_EC_KEY=no])
++        if test "$HAVE_TYPE_EC_KEY" = "yes"
++        then
++           AC_DEFINE([HAVE_TYPE_EC_KEY])
++           AC_MSG_RESULT([yes])
++        else
++           AC_MSG_RESULT([no])
++        fi
++    ],
++    [AC_MSG_RESULT([no])]
++)
++
++if test "$WITH_WOLFSSL" = "no"
++then
++	AC_MSG_CHECKING(whether to include openssl support)
++	AC_ARG_ENABLE(openssl, [  --disable-openssl       disable OpenSSL support],
++	  [ case "$enableval" in
++	    no) AC_MSG_RESULT(no); WITH_OPENSSL= ;;
++	    *) AC_MSG_RESULT(yes); WITH_OPENSSL=1 ;;
++	   esac],
++	   [ AC_MSG_RESULT(yes);   WITH_OPENSSL=1 ])
++
++	if test -n "$WITH_OPENSSL"; then
++	  AC_MSG_NOTICE(checking for components of OpenSSL)
++	  # first, we need to find the include file <openssl/ssl.h>
++	  AC_CACHE_VAL(sc_cv_have_openssl_ssl_h,
++	    [AC_TRY_COMPILE([#include <openssl/ssl.h>],[;],
++	      [sc_cv_have_openssl_ssl_h=yes; OPENSSL_ROOT=""; ],
++	      [sc_cv_have_openssl_ssl_h=no
++	       for D in "/sw" "/usr/local" "/opt/freeware" "/usr/sfw" "/usr/local/ssl"; do
++		I="$D/include"
++		i="$I/openssl/ssl.h"
++		if test -r "$i"; then
++		  #V_INCL="$V_INCL -I$I"
++		  CPPFLAGS="$CPPFLAGS -I$I"
++		  AC_MSG_NOTICE(found $i)
++		  sc_cv_have_openssl_ssl_h=yes; OPENSSL_ROOT="$D"
++		  break;
++		fi
++	      done])
++	  ])
++	  if test "$sc_cv_have_openssl_ssl_h" = "yes"; then
++	    AC_DEFINE(HAVE_OPENSSL_SSL_H)
++	  fi
++	  AC_MSG_NOTICE(checked for openssl/ssl.h... $sc_cv_have_openssl_ssl_h)
++	fi	# end checking for openssl/ssl.h
++	#
++	if test -n "$WITH_OPENSSL" -a "$sc_cv_have_openssl_ssl_h" = 'yes'; then
++	  # next, we search for the openssl library (libssl.*)
++	  # interesting: Linux only requires -lssl, FreeBSD requires -lssl -lcrypto
++	  # Note, version OpenSSL 0.9.7j requires -lcrypto even on Linux.
++	  AC_MSG_CHECKING(for libssl)
++	  AC_CACHE_VAL(sc_cv_have_libssl,
++	    [ LIBS0="$LIBS"
++	      if test -n "$OPENSSL_ROOT"; then
++		L="$OPENSSL_ROOT/lib"; LIBS="$LIBS -L$L -lssl"
++	      else
++		LIBS="$LIBS -lssl"
++	      fi
++	      AC_TRY_LINK([#include <openssl/ssl.h>],
++		[SSL_library_init();ERR_error_string()],
++		[sc_cv_have_libssl='yes'],
++		[ LIBS="$LIBS -lcrypto"
++		  AC_TRY_LINK([#include <openssl/ssl.h>],
++		  [SSL_library_init()],
++		  [sc_cv_have_libssl='yes'],
++		  [sc_cv_have_libssl='no'])
++	        ])
++	      if test "$sc_cv_have_libssl" != 'yes'; then
++		LIBS="$LIBS0"
++	      fi
++	    ]
++	  )
++	  if test "$sc_cv_have_libssl" = 'yes'; then
++	    AC_DEFINE(HAVE_LIBSSL)
++	  fi
++	  AC_MSG_RESULT($sc_cv_have_libssl)
++	fi
++	#
++	#    # a possible location for openssl (on Sourceforge/Solaris)
++	#    AC_CHECK_FILE(/usr/local/ssl/lib, LIBS="$LIBS -L/usr/local/ssl/lib/")
++	#    # sometimes on Solaris:
++	#    AC_CHECK_FILE(/pkgs/lib, LIBS="$LIBS -L/pkgs/lib/")
++	#    # for AIX 5.1 with Linux toolbox:
++	#    AC_CHECK_FILE(/opt/freeware/lib, LIBS="$LIBS -L/opt/freeware/lib/")
++	#
++	#    AC_CHECK_LIB(crypto, main)
++	#    AC_CHECK_LIB(ssl, main)
++	#
++	#    # MacOSX has openssl includes in another directory
++	#    if test -d /sw/include/; then
++	#	V_INCL="$V_INCL -I/sw/include"
++	#    # and Solaris at sourceforge here:
++	#    elif test -d /usr/local/ssl/include/; then
++	#	V_INCL="$V_INCL -I/usr/local/ssl/include"
++	#    # and AIX 5.1 with Linux toolbox:
++	#    elif test -d /opt/freeware/include; then
++	#	V_INCL="$V_INCL -I/opt/freeware/include"
++	#    fi
++	#fi
++	if test -n "$WITH_OPENSSL"; then
++	  if test "$sc_cv_have_openssl_ssl_h" = "yes" -a "$sc_cv_have_libssl" = "yes"; then
++	    AC_DEFINE(WITH_OPENSSL)
++	  else
++	    AC_MSG_WARN([not all components of OpenSSL found, disabling it]);
++	  fi
+ 	fi
+-      done])
+-  ])
+-  if test "$sc_cv_have_openssl_ssl_h" = "yes"; then
+-    AC_DEFINE(HAVE_OPENSSL_SSL_H)
+-  fi
+-  AC_MSG_NOTICE(checked for openssl/ssl.h... $sc_cv_have_openssl_ssl_h)
+-fi	# end checking for openssl/ssl.h
+-#
+-if test -n "$WITH_OPENSSL" -a "$sc_cv_have_openssl_ssl_h" = 'yes'; then
+-  # next, we search for the openssl library (libssl.*)
+-  # interesting: Linux only requires -lssl, FreeBSD requires -lssl -lcrypto
+-  # Note, version OpenSSL 0.9.7j requires -lcrypto even on Linux.
+-  AC_MSG_CHECKING(for libssl)
+-  AC_CACHE_VAL(sc_cv_have_libssl,
+-    [ LIBS0="$LIBS"
+-      if test -n "$OPENSSL_ROOT"; then
+-	L="$OPENSSL_ROOT/lib"; LIBS="$LIBS -L$L -lssl"
+-      else
+-	LIBS="$LIBS -lssl"
+-      fi
+-      AC_TRY_LINK([#include <openssl/ssl.h>],
+-	[SSL_library_init();ERR_error_string()],
+-	[sc_cv_have_libssl='yes'],
+-	[ LIBS="$LIBS -lcrypto"
+-	  AC_TRY_LINK([#include <openssl/ssl.h>],
+-	  [SSL_library_init()],
+-	  [sc_cv_have_libssl='yes'],
+-	  [sc_cv_have_libssl='no'])
+-        ])
+-      if test "$sc_cv_have_libssl" != 'yes'; then
+-	LIBS="$LIBS0"
+-      fi
+-    ]
+-  )
+-  if test "$sc_cv_have_libssl" = 'yes'; then
+-    AC_DEFINE(HAVE_LIBSSL)
+-  fi
+-  AC_MSG_RESULT($sc_cv_have_libssl)
+-fi
+-#
+-#    # a possible location for openssl (on Sourceforge/Solaris)
+-#    AC_CHECK_FILE(/usr/local/ssl/lib, LIBS="$LIBS -L/usr/local/ssl/lib/")
+-#    # sometimes on Solaris:
+-#    AC_CHECK_FILE(/pkgs/lib, LIBS="$LIBS -L/pkgs/lib/")
+-#    # for AIX 5.1 with Linux toolbox:
+-#    AC_CHECK_FILE(/opt/freeware/lib, LIBS="$LIBS -L/opt/freeware/lib/")
+-#
+-#    AC_CHECK_LIB(crypto, main)
+-#    AC_CHECK_LIB(ssl, main)
+-#
+-#    # MacOSX has openssl includes in another directory
+-#    if test -d /sw/include/; then
+-#	V_INCL="$V_INCL -I/sw/include"
+-#    # and Solaris at sourceforge here:
+-#    elif test -d /usr/local/ssl/include/; then
+-#	V_INCL="$V_INCL -I/usr/local/ssl/include"
+-#    # and AIX 5.1 with Linux toolbox:
+-#    elif test -d /opt/freeware/include; then
+-#	V_INCL="$V_INCL -I/opt/freeware/include"
+-#    fi
+-#fi
+-if test -n "$WITH_OPENSSL"; then
+-  if test "$sc_cv_have_openssl_ssl_h" = "yes" -a "$sc_cv_have_libssl" = "yes"; then
+-    AC_DEFINE(WITH_OPENSSL)
+-  else
+-    AC_MSG_WARN([not all components of OpenSSL found, disabling it]);
+-  fi
+-fi
+ 
+-if test -n "$WITH_OPENSSL"; then
+-AC_MSG_CHECKING(whether to include OpenSSL method option)
+-AC_ARG_ENABLE(openssl-method, [  --enable-openssl-method       enable OpenSSL method option],
+-	      [case "$enableval" in
+-	       no) AC_MSG_RESULT(no);;
+-	       *) AC_DEFINE(WITH_OPENSSL_METHOD) WITH_OPENSSL_METHOD=1; AC_MSG_RESULT(yes);;
+-	       esac],
+-	       [AC_MSG_RESULT(no)])
++	if test -n "$WITH_OPENSSL"; then
++	AC_MSG_CHECKING(whether to include OpenSSL method option)
++	AC_ARG_ENABLE(openssl-method, [  --enable-openssl-method       enable OpenSSL method option],
++		      [case "$enableval" in
++		       no) AC_MSG_RESULT(no);;
++		       *) AC_DEFINE(WITH_OPENSSL_METHOD) WITH_OPENSSL_METHOD=1; AC_MSG_RESULT(yes);;
++		       esac],
++		       [AC_MSG_RESULT(no)])
++	fi
+ fi
+ 
+ AC_MSG_CHECKING(whether to include deprecated resolver option)
+@@ -586,92 +653,95 @@ AC_ARG_ENABLE(res-deprecated, [  --enable-res-deprecated       enable deprecated
+ 	       esac],
+ 	       [AC_MSG_RESULT(no)])
+ 
+-# check for fips support
+-AC_MSG_CHECKING(whether to include openssl fips support)
+-AC_ARG_ENABLE(fips, [  --enable-fips          enable OpenSSL FIPS support],
+-  [ case "$enableval" in
+-    yes) AC_MSG_RESULT(yes); WITH_FIPS=1 ;;
+-    *) AC_MSG_RESULT(no); WITH_FIPS= ;;
+-   esac],
+-   [ AC_MSG_RESULT(no);   WITH_FIPS= ])
+-
+-if test -n "$WITH_FIPS"; then
+-  if test -n "$WITH_OPENSSL"; then
+-    AC_CHECK_PROG(HAVE_FIPSLD, fipsld, 1)
+-    if test "$sc_cv_have_openssl_ssl_h" != "yes" -o "$sc_cv_have_libssl" != "yes" -o ! "$HAVE_FIPSLD";
+- then
+-      AC_MSG_WARN([not all components of OpenSSL found, disabling FIPS]);
+-      WITH_FIPS=
+-    fi
+-  else
+-    AC_MSG_WARN([must enable OpenSSL to enable FIPS; use --enable-openssl]);
+-  fi
+-fi
++if test "$WITH_WOLFSSL" = "no"
++then
++	# check for fips support
++	AC_MSG_CHECKING(whether to include openssl fips support)
++	AC_ARG_ENABLE(fips, [  --enable-fips          enable OpenSSL FIPS support],
++	  [ case "$enableval" in
++	    yes) AC_MSG_RESULT(yes); WITH_FIPS=1 ;;
++	    *) AC_MSG_RESULT(no); WITH_FIPS= ;;
++	   esac],
++	   [ AC_MSG_RESULT(no);   WITH_FIPS= ])
++
++	if test -n "$WITH_FIPS"; then
++	  if test -n "$WITH_OPENSSL"; then
++	    AC_CHECK_PROG(HAVE_FIPSLD, fipsld, 1)
++	    if test "$sc_cv_have_openssl_ssl_h" != "yes" -o "$sc_cv_have_libssl" != "yes" -o ! "$HAVE_FIPSLD";
++	 then
++	      AC_MSG_WARN([not all components of OpenSSL found, disabling FIPS]);
++	      WITH_FIPS=
++	    fi
++	  else
++	    AC_MSG_WARN([must enable OpenSSL to enable FIPS; use --enable-openssl]);
++	  fi
++	fi
+ 
+-if test -n "$WITH_FIPS"; then
+-  AC_MSG_CHECKING(for components of OpenSSL FIPS)
+-  # first, we need to find the include file <openssl/fips.h>
+-  AC_CACHE_VAL(sc_cv_have_openssl_fips_h,
+-    [AC_TRY_COMPILE([#define OPENSSL_FIPS
+-#include <stddef.h>
+-#include <openssl/fips.h>],[;],
+-      [sc_cv_have_openssl_fips_h=yes; ],
+-      [sv_cv_have_openssl_fips_h=no
+-        if test -n "$OPENSSL_ROOT"; then
+-          I="$OPENSSL_ROOT/include"
+-          i="$I/openssl/fips.h"
+-          if test -r "$i"; then
+-            AC_MSG_NOTICE(found $i)
+-            sc_cv_have_openssl_fips_h=yes;
+-          fi
+-        fi
+-      ]
+-    )]
+-  )
+-  if test "$sv_cv_have_openssl_fips_h" = "yes"; then
+-    AC_DEFINE(HAVE_OPENSSL_FIPS_H)
+-  fi
+-  AC_MSG_NOTICE(checked for openssl/fips.h... $sc_cv_have_openssl_ssl_h)
+-fi
++	if test -n "$WITH_FIPS"; then
++	  AC_MSG_CHECKING(for components of OpenSSL FIPS)
++	  # first, we need to find the include file <openssl/fips.h>
++	  AC_CACHE_VAL(sc_cv_have_openssl_fips_h,
++	    [AC_TRY_COMPILE([#define OPENSSL_FIPS
++	#include <stddef.h>
++	#include <openssl/fips.h>],[;],
++	      [sc_cv_have_openssl_fips_h=yes; ],
++	      [sv_cv_have_openssl_fips_h=no
++	        if test -n "$OPENSSL_ROOT"; then
++	          I="$OPENSSL_ROOT/include"
++	          i="$I/openssl/fips.h"
++	          if test -r "$i"; then
++	            AC_MSG_NOTICE(found $i)
++	            sc_cv_have_openssl_fips_h=yes;
++	          fi
++	        fi
++	      ]
++	    )]
++	  )
++	  if test "$sv_cv_have_openssl_fips_h" = "yes"; then
++	    AC_DEFINE(HAVE_OPENSSL_FIPS_H)
++	  fi
++	  AC_MSG_NOTICE(checked for openssl/fips.h... $sc_cv_have_openssl_ssl_h)
++	fi
+ 
+-if test -n "$WITH_FIPS" -a "$sc_cv_have_openssl_fips_h" = 'yes'; then
+-  # check for the libcrypto library with fips support
+-  AC_MSG_CHECKING(for libcrypto with FIPS support)
+-  AC_CACHE_VAL(sc_cv_have_libcrypto,
+-    [ LIBS0="$LIBS"
+-      echo $LIBS | grep -q "\-lcrypto"
+-      if test $? -ne 0; then
+-        if test -n "$OPENSSL_ROOT"; then
+-          L="$OPENSSL_ROOT/lib"; LIBS="$LIBS -L$L -lcrypto"
+-        else
+-          LIBS="$LIBS -lcrypto"
+-        fi
+-      fi
+-      AC_TRY_LINK([#define OPENSSL_FIPS
+-#include <openssl/ssl.h>
+-#include <openssl/fips.h>],
+-        [int res = FIPS_mode_set(1);],
+-        [sc_cv_have_libcrypto='yes'],
+-        [sc_cv_have_libcrypto='no']
+-      )
+-      if test "$sc_cv_have_libcrypto" != 'yes'; then
+-        LIBS="$LIBS0"
+-      fi
+-    ]
+-  )
+-  if test "$sc_cv_have_libcrypto" = 'yes'; then
+-    AC_DEFINE(HAVE_LIBCRYPTO)
+-  fi
+-  AC_MSG_RESULT($sc_cv_have_libcrypto)
+-fi
++	if test -n "$WITH_FIPS" -a "$sc_cv_have_openssl_fips_h" = 'yes'; then
++	  # check for the libcrypto library with fips support
++	  AC_MSG_CHECKING(for libcrypto with FIPS support)
++	  AC_CACHE_VAL(sc_cv_have_libcrypto,
++	    [ LIBS0="$LIBS"
++	      echo $LIBS | grep -q "\-lcrypto"
++	      if test $? -ne 0; then
++	        if test -n "$OPENSSL_ROOT"; then
++	          L="$OPENSSL_ROOT/lib"; LIBS="$LIBS -L$L -lcrypto"
++	        else
++	          LIBS="$LIBS -lcrypto"
++	        fi
++	      fi
++	      AC_TRY_LINK([#define OPENSSL_FIPS
++	#include <openssl/ssl.h>
++	#include <openssl/fips.h>],
++	        [int res = FIPS_mode_set(1);],
++	        [sc_cv_have_libcrypto='yes'],
++	        [sc_cv_have_libcrypto='no']
++	      )
++	      if test "$sc_cv_have_libcrypto" != 'yes'; then
++	        LIBS="$LIBS0"
++	      fi
++	    ]
++	  )
++	  if test "$sc_cv_have_libcrypto" = 'yes'; then
++	    AC_DEFINE(HAVE_LIBCRYPTO)
++	  fi
++	  AC_MSG_RESULT($sc_cv_have_libcrypto)
++	fi
+ 
+-if test -n "$WITH_FIPS"; then
+-  if test "$sc_cv_have_openssl_fips_h" = 'yes' -a "$sc_cv_have_libcrypto" = 'yes'; then
+-    AC_DEFINE(WITH_FIPS)
+-    AC_DEFINE(OPENSSL_FIPS)
+-  else
+-    AC_MSG_WARN([not all components of OpenSSL FIPS found, disabling it]);
+-  fi
++	if test -n "$WITH_FIPS"; then
++	  if test "$sc_cv_have_openssl_fips_h" = 'yes' -a "$sc_cv_have_libcrypto" = 'yes'; then
++	    AC_DEFINE(WITH_FIPS)
++	    AC_DEFINE(OPENSSL_FIPS)
++	  else
++	    AC_MSG_WARN([not all components of OpenSSL FIPS found, disabling it]);
++	  fi
++	fi
+ fi
+ 
+ AC_MSG_CHECKING(whether to include tun/tap address support)
+@@ -1437,44 +1507,47 @@ AC_CHECK_FUNC(setenv, AC_DEFINE(HAVE_SETENV),
+ dnl Search for unsetenv()
+ AC_CHECK_FUNC(unsetenv, AC_DEFINE(HAVE_UNSETENV))
+ 
+-AC_CHECK_FUNC(TLS_client_method, AC_DEFINE(HAVE_TLS_client_method) ac_cv_have_tls_client_method=yes, AC_CHECK_LIB(crypt, TLS_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(TLS_server_method, AC_DEFINE(HAVE_TLS_server_method) ac_cv_have_tls_server_method=yes, AC_CHECK_LIB(crypt, TLS_server_method, [LIBS=-lcrypt $LIBS]))
+-if test -n "$WITH_OPENSSL_METHOD" -o -z "$ac_cv_have_tls_client_method" -o -z "$ac_cv_have_tls_server_method" ; then
+-dnl Search for SSLv2_client_method, SSLv2_server_method
+-AC_CHECK_FUNC(SSLv2_client_method, AC_DEFINE(HAVE_SSLv2_client_method), AC_CHECK_LIB(crypt, SSLv2_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(SSLv2_server_method, AC_DEFINE(HAVE_SSLv2_server_method), AC_CHECK_LIB(crypt, SSLv2_server_method, [LIBS=-lcrypt $LIBS]))
+-dnl 
+-AC_CHECK_FUNC(SSLv3_client_method, AC_DEFINE(HAVE_SSLv3_client_method), AC_CHECK_LIB(crypt, SSLv3_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(SSLv3_server_method, AC_DEFINE(HAVE_SSLv3_server_method), AC_CHECK_LIB(crypt, SSLv3_server_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(SSLv23_client_method, AC_DEFINE(HAVE_SSLv23_client_method), AC_CHECK_LIB(crypt, SSLv23_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(SSLv23_server_method, AC_DEFINE(HAVE_SSLv23_server_method), AC_CHECK_LIB(crypt, SSLv23_server_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(TLSv1_client_method, AC_DEFINE(HAVE_TLSv1_client_method), AC_CHECK_LIB(crypt, TLSv1_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(TLSv1_server_method, AC_DEFINE(HAVE_TLSv1_server_method), AC_CHECK_LIB(crypt, TLSv1_server_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(TLSv1_1_client_method, AC_DEFINE(HAVE_TLSv1_1_client_method), AC_CHECK_LIB(crypt, TLSv1_1_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(TLSv1_1_server_method, AC_DEFINE(HAVE_TLSv1_1_server_method), AC_CHECK_LIB(crypt, TLSv1_1_server_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(TLSv1_2_client_method, AC_DEFINE(HAVE_TLSv1_2_client_method), AC_CHECK_LIB(crypt, TLSv1_2_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(TLSv1_2_server_method, AC_DEFINE(HAVE_TLSv1_2_server_method), AC_CHECK_LIB(crypt, TLSv1_2_server_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(DTLSv1_client_method, AC_DEFINE(HAVE_DTLSv1_client_method), AC_CHECK_LIB(crypt, DTLSv1_client_method, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(DTLSv1_server_method, AC_DEFINE(HAVE_DTLSv1_server_method), AC_CHECK_LIB(crypt, DTLSv1_server_method, [LIBS=-lcrypt $LIBS]))
+-fi # $WITH_OPENSSL_METHOD
+-
+-AC_CHECK_FUNC(SSL_CTX_set_default_verify_paths, AC_DEFINE(HAVE_SSL_CTX_set_default_verify_paths))
+-AC_CHECK_FUNC(RAND_egd, AC_DEFINE(HAVE_RAND_egd), AC_CHECK_LIB(crypt, RAND_egd, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(DH_set0_pqg, AC_DEFINE(HAVE_DH_set0_pqg), AC_CHECK_LIB(crypt, DH_set0_pqg, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(ASN1_STRING_get0_data, AC_DEFINE(HAVE_ASN1_STRING_get0_data), AC_CHECK_LIB(crypt, ASN1_STRING_get0_data, [LIBS=-lcrypt $LIBS]))
+-AC_CHECK_FUNC(RAND_status, AC_DEFINE(HAVE_RAND_status))
+-AC_CHECK_FUNC(SSL_CTX_clear_mode, AC_DEFINE(HAVE_SSL_CTX_clear_mode))
+-
+-AC_MSG_CHECKING(for type EC_KEY)
+-AC_CACHE_VAL(sc_cv_type_EC_TYPE,
+-[AC_TRY_COMPILE([#include <openssl/ec.h>
+-],[EC_KEY *s;],
+-[sc_cv_type_EC_KEY=yes],
+-[sc_cv_type_EC_KEY=no])])
+-if test $sc_cv_type_EC_KEY = yes; then
+-   AC_DEFINE(HAVE_TYPE_EC_KEY)
+-fi
+-AC_MSG_RESULT($sc_cv_type_EC_KEY)
++if test "$WITH_WOLFSSL" = "no"
++then
++	AC_CHECK_FUNC(TLS_client_method, AC_DEFINE(HAVE_TLS_client_method) ac_cv_have_tls_client_method=yes, AC_CHECK_LIB(crypt, TLS_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(TLS_server_method, AC_DEFINE(HAVE_TLS_server_method) ac_cv_have_tls_server_method=yes, AC_CHECK_LIB(crypt, TLS_server_method, [LIBS=-lcrypt $LIBS]))
++	if test -n "$WITH_OPENSSL_METHOD" -o -z "$ac_cv_have_tls_client_method" -o -z "$ac_cv_have_tls_server_method" ; then
++	dnl Search for SSLv2_client_method, SSLv2_server_method
++	AC_CHECK_FUNC(SSLv2_client_method, AC_DEFINE(HAVE_SSLv2_client_method), AC_CHECK_LIB(crypt, SSLv2_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(SSLv2_server_method, AC_DEFINE(HAVE_SSLv2_server_method), AC_CHECK_LIB(crypt, SSLv2_server_method, [LIBS=-lcrypt $LIBS]))
++
++	AC_CHECK_FUNC(SSLv3_client_method, AC_DEFINE(HAVE_SSLv3_client_method), AC_CHECK_LIB(crypt, SSLv3_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(SSLv3_server_method, AC_DEFINE(HAVE_SSLv3_server_method), AC_CHECK_LIB(crypt, SSLv3_server_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(SSLv23_client_method, AC_DEFINE(HAVE_SSLv23_client_method), AC_CHECK_LIB(crypt, SSLv23_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(SSLv23_server_method, AC_DEFINE(HAVE_SSLv23_server_method), AC_CHECK_LIB(crypt, SSLv23_server_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(TLSv1_client_method, AC_DEFINE(HAVE_TLSv1_client_method), AC_CHECK_LIB(crypt, TLSv1_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(TLSv1_server_method, AC_DEFINE(HAVE_TLSv1_server_method), AC_CHECK_LIB(crypt, TLSv1_server_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(TLSv1_1_client_method, AC_DEFINE(HAVE_TLSv1_1_client_method), AC_CHECK_LIB(crypt, TLSv1_1_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(TLSv1_1_server_method, AC_DEFINE(HAVE_TLSv1_1_server_method), AC_CHECK_LIB(crypt, TLSv1_1_server_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(TLSv1_2_client_method, AC_DEFINE(HAVE_TLSv1_2_client_method), AC_CHECK_LIB(crypt, TLSv1_2_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(TLSv1_2_server_method, AC_DEFINE(HAVE_TLSv1_2_server_method), AC_CHECK_LIB(crypt, TLSv1_2_server_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(DTLSv1_client_method, AC_DEFINE(HAVE_DTLSv1_client_method), AC_CHECK_LIB(crypt, DTLSv1_client_method, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(DTLSv1_server_method, AC_DEFINE(HAVE_DTLSv1_server_method), AC_CHECK_LIB(crypt, DTLSv1_server_method, [LIBS=-lcrypt $LIBS]))
++	fi # $WITH_OPENSSL_METHOD
++
++	AC_CHECK_FUNC(SSL_CTX_set_default_verify_paths, AC_DEFINE(HAVE_SSL_CTX_set_default_verify_paths))
++	AC_CHECK_FUNC(RAND_egd, AC_DEFINE(HAVE_RAND_egd), AC_CHECK_LIB(crypt, RAND_egd, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(DH_set0_pqg, AC_DEFINE(HAVE_DH_set0_pqg), AC_CHECK_LIB(crypt, DH_set0_pqg, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(ASN1_STRING_get0_data, AC_DEFINE(HAVE_ASN1_STRING_get0_data), AC_CHECK_LIB(crypt, ASN1_STRING_get0_data, [LIBS=-lcrypt $LIBS]))
++	AC_CHECK_FUNC(RAND_status, AC_DEFINE(HAVE_RAND_status))
++	AC_CHECK_FUNC(SSL_CTX_clear_mode, AC_DEFINE(HAVE_SSL_CTX_clear_mode))
++
++	AC_MSG_CHECKING(for type EC_KEY)
++	AC_CACHE_VAL(sc_cv_type_EC_TYPE,
++	[AC_TRY_COMPILE([#include <openssl/ec.h>
++	],[EC_KEY *s;],
++	[sc_cv_type_EC_KEY=yes],
++	[sc_cv_type_EC_KEY=no])])
++	if test $sc_cv_type_EC_KEY = yes; then
++	   AC_DEFINE(HAVE_TYPE_EC_KEY)
++	fi
++	AC_MSG_RESULT($sc_cv_type_EC_KEY)
++fi
+ 
+ 
+ dnl Run time checks
+@@ -1976,18 +2049,21 @@ if test "$GCC" = yes; then
+    CFLAGS="$CFLAGS"
+ fi
+ 
+-# FIPS support requires compiling with fipsld.
+-# fipsld requires the FIPSLD_CC variable to be set to the original CC.
+-# This check must be done after all other checks that require compiling
+-# so that fipsld is not used by the configure script itself.
+-if test -n "$WITH_FIPS"; then
+-  if test "$sc_cv_have_openssl_fips_h" = 'yes' -a "$sc_cv_have_libcrypto" = 'yes'; then
+-    FIPSLD_CC=$CC
+-    if test "${FIPSLD+set}" != set ; then
+-        FIPSLD=fipsld
+-    fi
+-    CC="FIPSLD_CC=$CC $FIPSLD"
+-  fi
++if test "$WITH_WOLFSSL" = "no"
++then
++	# FIPS support requires compiling with fipsld.
++	# fipsld requires the FIPSLD_CC variable to be set to the original CC.
++	# This check must be done after all other checks that require compiling
++	# so that fipsld is not used by the configure script itself.
++	if test -n "$WITH_FIPS"; then
++	  if test "$sc_cv_have_openssl_fips_h" = 'yes' -a "$sc_cv_have_libcrypto" = 'yes'; then
++	    FIPSLD_CC=$CC
++	    if test "${FIPSLD+set}" != set ; then
++	        FIPSLD=fipsld
++	    fi
++	    CC="FIPSLD_CC=$CC $FIPSLD"
++	  fi
++	fi
+ fi
+ AC_SUBST(FIPSLD_CC)
+ 
+@@ -2018,7 +2094,7 @@ AC_MSG_RESULT($sc_cv_var_environ)
+ if test "$BUILD_DATE"; then
+   AC_DEFINE_UNQUOTED(BUILD_DATE, ["$BUILD_DATE"])
+ else
+-  AC_DEFINE(BUILD_DATE, [__DATE__" "__TIME__])
++  AC_DEFINE([BUILD_DATE], [__DATE__" "__TIME__], [])
+ fi
+ 
+ AC_OUTPUT(Makefile)
+diff --git a/sysincludes.h b/sysincludes.h
+index afcedd3..66fb76d 100644
+--- a/sysincludes.h
++++ b/sysincludes.h
+@@ -181,6 +181,9 @@
+ #  endif
+ #endif /* WITH_READLINE */
+ #if WITH_OPENSSL
++#if WITH_WOLFSSL
++#include <wolfssl/options.h>
++#endif
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
+ #include <openssl/rand.h>
+diff --git a/xio-openssl.c b/xio-openssl.c
+index 132e8ea..b32959f 100644
+--- a/xio-openssl.c
++++ b/xio-openssl.c
+@@ -625,9 +625,14 @@ int _xioopen_openssl_listen(struct single *xfd,
+ 	    Msg(level, "I/O error");	/*!*/
+ 	    while (err = ERR_get_error()) {
+ 	       ERR_error_string_n(err, error_string, sizeof(error_string));
+-	       Msg4(level, "SSL_accept(): %s / %s / %s / %s", error_string,
+-		    ERR_lib_error_string(err), ERR_func_error_string(err),
+-		    ERR_reason_error_string(err));
++       #ifdef WITH_WOLFSSL
++          Msg2(level, "SSL_accept(): %s / %s", error_string,
++               ERR_reason_error_string(err));
++       #else
++          Msg4(level, "SSL_accept(): %s / %s / %s / %s", error_string,
++               ERR_lib_error_string(err), ERR_func_error_string(err),
++               ERR_reason_error_string(err));
++       #endif
+ 	    }
+ 	    /* Msg1(level, "SSL_accept(): %s", ERR_error_string(e, buf));*/
+ 	 }
+@@ -719,7 +724,12 @@ int
+    bool opt_fips = false;
+    const SSL_METHOD *method = NULL;
+    char *me_str = NULL;	/* method string */
++/* By default, let wolfSSL pick the strongest cipher */
++#ifdef WITH_WOLFSSL
++   char *ci_str = NULL;
++#else
+    char *ci_str = "HIGH:-NULL:-PSK:-aNULL";	/* cipher string */
++#endif
+    char *opt_key  = NULL;	/* file name of client private key */
+    char *opt_dhparam = NULL;	/* file name of DH params */
+    char *opt_cafile = NULL;	/* certificate authority file */
+@@ -767,6 +777,10 @@ int
+    OpenSSL_add_all_digests();
+    sycSSL_load_error_strings();
+ 
++#if defined(WITH_WOLFSSL) && defined(DEBUG_WOLFSSL)
++   wolfSSL_Debugging_ON();
++#endif
++
+    /* OpenSSL preparation */
+    sycSSL_library_init();
+    
+@@ -786,7 +800,13 @@ int
+ #endif
+ #if HAVE_SSLv23_client_method
+ 	 } else if (!strcasecmp(me_str, "SSL23")) {
++    #if defined(WITH_WOLFSSL) && defined(WOLFSSL_TLS13)
++      /* Can't use sycSSLv23_client_method because wolfSSL will default to
++       * TLS 1.3, which doesn't work with socat." */
++       method = sycTLSv1_2_client_method();
++    #else
+ 	    method = sycSSLv23_client_method();
++    #endif
+ #endif
+ #if HAVE_TLSv1_client_method
+ 	 } else if (!strcasecmp(me_str, "TLS1") || !strcasecmp(me_str, "TLS1.0")) {
+@@ -808,9 +828,9 @@ int
+ 	    Error1("openssl-method=\"%s\": method unknown or not provided by library", me_str);
+ 	 }
+       } else {
+-#if   HAVE_TLS_client_method
++#if   HAVE_TLS_client_method && !(defined(WITH_WOLFSSL) && defined(WOLFSSL_TLS13))
+ 	 method = TLS_client_method();
+-#elif HAVE_SSLv23_client_method
++#elif HAVE_SSLv23_client_method && !(defined(WITH_WOLFSSL) && defined(WOLFSSL_TLS13))
+ 	 method = sycSSLv23_client_method();
+ #elif HAVE_TLSv1_2_client_method
+ 	 method = sycTLSv1_2_client_method();
+@@ -840,7 +860,13 @@ int
+ #endif
+ #if HAVE_SSLv23_server_method
+ 	 } else if (!strcasecmp(me_str, "SSL23")) {
++    #if defined(WITH_WOLFSSL) && defined(WOLFSSL_TLS13)
++       /* Can't use sycSSLv23_server_method because wolfSSL will default to
++        * TLS 1.3, which doesn't work with socat." */
++       method = sycTLSv1_2_server_method();
++    #else
+ 	    method = sycSSLv23_server_method();
++    #endif
+ #endif
+ #if HAVE_TLSv1_server_method
+ 	 } else if (!strcasecmp(me_str, "TLS1") || !strcasecmp(me_str, "TLS1.0")) {
+@@ -862,9 +888,9 @@ int
+ 	    Error1("openssl-method=\"%s\": method unknown or not provided by library", me_str);
+ 	 }
+       } else {
+-#if   HAVE_TLS_server_method
++#if   HAVE_TLS_server_method && !(defined(WITH_WOLFSSL) && defined(WOLFSSL_TLS13))
+ 	 method = TLS_server_method();
+-#elif HAVE_SSLv23_server_method
++#elif HAVE_SSLv23_server_method && !(defined(WITH_WOLFSSL) && defined(WOLFSSL_TLS13))
+ 	 method = sycSSLv23_server_method();
+ #elif HAVE_TLSv1_2_server_method
+ 	 method = sycTLSv1_2_server_method();
+@@ -1140,7 +1166,7 @@ static int openssl_SSL_ERROR_SSL(int level, const char *funcname) {
+       Debug1("ERR_get_error(): %lx", e);
+       if
+ 	 (
+-#if defined(OPENSSL_IS_BORINGSSL)
++#if defined(OPENSSL_IS_BORINGSSL) || defined(WITH_WOLFSSL)
+ 	  0  /* BoringSSL's RNG always succeeds. */
+ #elif defined(HAVE_RAND_status)
+ 	  ERR_GET_LIB(e) == ERR_LIB_RAND && RAND_status() != 1
+@@ -1568,9 +1594,14 @@ static int xioSSL_connect(struct single *xfd, const char *opt_commonname,
+ 	    Msg(level, "I/O error");	/*!*/
+ 	    while (err = ERR_get_error()) {
+ 	       ERR_error_string_n(err, error_string, sizeof(error_string));
+-	       Msg4(level, "SSL_connect(): %s / %s / %s / %s", error_string,
+-		    ERR_lib_error_string(err), ERR_func_error_string(err),
+-		    ERR_reason_error_string(err));
++       #ifdef WITH_WOLFSSL
++          Msg2(level, "SSL_connect(): %s / %s", error_string,
++               ERR_reason_error_string(err));
++       #else
++          Msg4(level, "SSL_connect(): %s / %s / %s / %s", error_string,
++               ERR_lib_error_string(err), ERR_func_error_string(err),
++               ERR_reason_error_string(err));
++       #endif
+ 	    }
+ 	 }
+ 	 status = STAT_RETRYLATER;
+@@ -1628,9 +1659,14 @@ ssize_t xioread_openssl(struct single *pipe, void *buff, size_t bufsiz) {
+ 	    Error("I/O error");	/*!*/
+ 	    while (err = ERR_get_error()) {
+ 	       ERR_error_string_n(err, error_string, sizeof(error_string));
+-	       Error4("SSL_read(): %s / %s / %s / %s", error_string,
+-		      ERR_lib_error_string(err), ERR_func_error_string(err),
+-		      ERR_reason_error_string(err));
++       #ifdef WITH_WOLFSSL
++          Error2("SSL_read(): %s / %s", error_string,
++                 ERR_reason_error_string(err));
++       #else
++          Error4("SSL_read(): %s / %s / %s / %s", error_string,
++                 ERR_lib_error_string(err), ERR_func_error_string(err),
++                 ERR_reason_error_string(err));
++       #endif
+ 	    }
+ 	 }
+ 	 break;
+@@ -1687,9 +1723,14 @@ ssize_t xiowrite_openssl(struct single *pipe, const void *buff, size_t bufsiz) {
+ 	    Error("I/O error");	/*!*/
+ 	    while (err = ERR_get_error()) {
+ 	       ERR_error_string_n(err, error_string, sizeof(error_string));
+-	       Error4("SSL_write(): %s / %s / %s / %s", error_string,
+-		      ERR_lib_error_string(err), ERR_func_error_string(err),
+-		      ERR_reason_error_string(err));
++       #ifdef WITH_WOLFSSL
++          Error2("SSL_write(): %s / %s", error_string,
++                 ERR_reason_error_string(err));
++       #else
++          Error4("SSL_write(): %s / %s / %s / %s", error_string,
++                 ERR_lib_error_string(err), ERR_func_error_string(err),
++                 ERR_reason_error_string(err));
++       #endif
+ 	    }
+ 	 }
+ 	 break;

--- a/recipes-connectivity/socat/socat_1.7.3.4.bbappend
+++ b/recipes-connectivity/socat/socat_1.7.3.4.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += " file://socat-1.7.3.4.patch"
+DEPENDS_remove = "openssl"
+DEPENDS += "wolfssl"
+EXTRA_OECONF += "--with-wolfssl=${STAGING_EXECPREFIXDIR}"

--- a/recipes-connectivity/socat/wolfssl_%.bbappend
+++ b/recipes-connectivity/socat/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-opensslextra --enable-opensslall"

--- a/recipes-extended/rsyslog/files/rsyslog-8.2106.0.patch
+++ b/recipes-extended/rsyslog/files/rsyslog-8.2106.0.patch
@@ -1,0 +1,454 @@
+diff --git a/Makefile.am b/Makefile.am
+index b3119fb31..d6a404582 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -486,8 +486,14 @@ DISTCHECK_CONFIGURE_FLAGS+= --disable-gnutls-tests
+ endif
+ 
+ if ENABLE_OPENSSL
++if !ENABLE_WOLFSSL
+ DISTCHECK_CONFIGURE_FLAGS+= --enable-openssl
+ endif
++endif
++
++if ENABLE_WOLFSSL
++DISTCHECK_CONFIGURE_FLAGS+= --with-wolfssl
++endif
+ 
+ if ENABLE_MYSQL
+ DISTCHECK_CONFIGURE_FLAGS+= --enable-mysql
+diff --git a/configure.ac b/configure.ac
+index 4343d431c..443ccf86d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1049,6 +1049,20 @@ AC_ARG_ENABLE(clickhouse_tests,
+ )
+ AM_CONDITIONAL(ENABLE_CLICKHOUSE_TESTS, test x$enable_clickhouse_tests = xyes)
+ 
++AC_ARG_WITH(wolfssl,
++    AS_HELP_STRING([--with-wolfssl]=DIR,
++		   [Enable wolfssl support @<:@default=no@:>@]),
++[
++	AC_SUBST(WOLFSSL_CFLAGS,  ["-I${withval}/include/wolfssl -I${withval}/include"])
++	AC_SUBST(WOLFSSL_LIBS,    ["-L${withval}/lib -lwolfssl"])
++	enable_wolfssl=yes
++	AC_DEFINE([ENABLE_OPENSSL], [1], [Indicator that openssl is present])
++	AC_DEFINE([ENABLE_WOLFSSL], [1], [Indicator that wolfssl is present])
++],
++[
++	enable_wolfssl=no
++])
++AM_CONDITIONAL(ENABLE_WOLFSSL, [test "x$enable_wolfssl" = "xyes"])
+ 
+ # openssl support
+ AC_ARG_ENABLE(openssl,
+@@ -1065,8 +1079,7 @@ if test "x$enable_openssl" = "xyes"; then
+ 	AC_DEFINE([ENABLE_OPENSSL], [1], [Indicator that openssl is present])
+ 	save_libs=$LIBS
+ fi
+-AM_CONDITIONAL(ENABLE_OPENSSL, test x$enable_openssl = xyes)
+-
++AM_CONDITIONAL(ENABLE_OPENSSL, [test "x$enable_openssl" = "xyes" || test "x$enable_wolfssl" = "xyes"])
+ 
+ # GnuTLS support
+ AC_ARG_ENABLE(gnutls,
+@@ -2813,6 +2826,7 @@ echo "    hiredis support enabled:                  $enable_omhiredis"
+ echo
+ echo "---{ protocol support }---"
+ echo "    openssl network stream driver enabled:    $enable_openssl"
++echo "    wolfssl network stream driver enabled:    $enable_wolfssl"
+ echo "    GnuTLS network stream driver enabled:     $enable_gnutls"
+ echo "    GSSAPI Kerberos 5 support enabled:        $enable_gssapi_krb5"
+ echo "    RELP support enabled:                     $enable_relp"
+diff --git a/runtime/Makefile.am b/runtime/Makefile.am
+index f62773952..867d31dca 100644
+--- a/runtime/Makefile.am
++++ b/runtime/Makefile.am
+@@ -207,10 +207,16 @@ endif # if ENABLE_INET
+ if ENABLE_OPENSSL
+ pkglib_LTLIBRARIES += lmnsd_ossl.la
+ lmnsd_ossl_la_SOURCES = nsd_ossl.c nsd_ossl.h nsdsel_ossl.c  nsdsel_ossl.h
+-lmnsd_ossl_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(OPENSSL_CFLAGS)
+ lmnsd_ossl_la_LDFLAGS = -module -avoid-version
++
++if ENABLE_WOLFSSL
++lmnsd_ossl_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(WOLFSSL_CFLAGS)
++lmnsd_ossl_la_LIBADD = $(WOLFSSL_LIBS)
++else
++lmnsd_ossl_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(OPENSSL_CFLAGS)
+ lmnsd_ossl_la_LIBADD = $(OPENSSL_LIBS)
+ endif
++endif
+ 
+ #
+ # GnuTLS netstream driver
+diff --git a/runtime/nsd_ossl.c b/runtime/nsd_ossl.c
+index 79347916e..a6d699a12 100644
+--- a/runtime/nsd_ossl.c
++++ b/runtime/nsd_ossl.c
+@@ -28,6 +28,9 @@
+ #include <stdlib.h>
+ #include <assert.h>
+ #include <string.h>
++#ifdef ENABLE_WOLFSSL
++#include <wolfssl/options.h>
++#endif
+ #include <openssl/ssl.h>
+ #include <openssl/x509v3.h>
+ #include <openssl/err.h>
+@@ -66,6 +69,9 @@ DEFobjCurrIf(datetime)
+ DEFobjCurrIf(nsd_ptcp)
+ 
+ /* OpenSSL API differences */
++#ifdef ENABLE_WOLFSSL
++#define RSYSLOG_X509_NAME_oneline(X509CERT) X509_get_subject_name(X509CERT)
++#else
+ #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+ 	#define RSYSLOG_X509_NAME_oneline(X509CERT) X509_get_subject_name(X509CERT)
+ 	#define RSYSLOG_BIO_method_name(SSLBIO) BIO_method_name(SSLBIO)
+@@ -77,6 +83,7 @@ DEFobjCurrIf(nsd_ptcp)
+ 	#define RSYSLOG_BIO_number_read(SSLBIO) SSLBIO->num
+ 	#define RSYSLOG_BIO_number_written(SSLBIO) SSLBIO->num
+ #endif
++#endif /* ENABLE_WOLFSSL */
+ 
+ 
+ static int bGlblSrvrInitDone = 0;	/**< 0 - server global init not yet done, 1 - already done */
+@@ -92,6 +99,9 @@ static int bAnonInit;
+ static MUTEX_TYPE anonInit_mut = PTHREAD_MUTEX_INITIALIZER;
+ 
+ /*--------------------------------------MT OpenSSL helpers ------------------------------------------*/
++/* wolfSSL doesn't require any special setup to be used in a multi-threaded
++ * context, unlike OpenSSL. */
++#ifndef ENABLE_WOLFSSL
+ static MUTEX_TYPE *mutex_buf = NULL;
+ 
+ void locking_function(int mode, int n,
+@@ -187,6 +197,7 @@ int opensslh_THREAD_cleanup(void)
+ 	DBGPRINTF("openssl: multithread cleanup finished\n");
+ 	return 1;
+ }
++#endif /* !ENABLE_WOLFSSL */
+ /*-------------------------------------- MT OpenSSL helpers -----------------------------------------*/
+ 
+ /*--------------------------------------OpenSSL helpers ------------------------------------------*/
+@@ -226,8 +237,15 @@ int verify_callback(int status, X509_STORE_CTX *store)
+ 		/* Retrieve all needed pointers */
+ 		X509 *cert = X509_STORE_CTX_get_current_cert(store);
+ 		int depth = X509_STORE_CTX_get_error_depth(store);
+-		int err = X509_STORE_CTX_get_error(store);
+ 		SSL* ssl = X509_STORE_CTX_get_ex_data(store, SSL_get_ex_data_X509_STORE_CTX_idx());
++		/* In wolfSSL, the errors being checked below (e.g. 
++		 * X509_V_ERR_CERT_HAS_EXPIRED) are accessed via SSL_get_verify_result
++		 * rather than X509_STORE_CTX_get_error. */
++		#ifdef ENABLE_WOLFSSL
++		int err = SSL_get_verify_result(ssl);
++		#else
++		int err = X509_STORE_CTX_get_error(store);
++		#endif
+ 		int iVerifyMode = SSL_get_verify_mode(ssl);
+ 		nsd_ossl_t *pThis = (nsd_ossl_t*) SSL_get_ex_data(ssl, 0);
+ 		assert(pThis != NULL);
+@@ -296,6 +314,9 @@ int verify_callback(int status, X509_STORE_CTX *store)
+ 	return status;
+ }
+ 
++/* wolfSSL doesn't support all the functions being used in this debug code (e.g.
++ * BIO_number_read), so we don't compile it for the wolfSSL case. */
++#ifndef ENABLE_WOLFSSL
+ long BIO_debug_callback(BIO *bio, int cmd, const char __attribute__((unused)) *argp,
+ 			int argi, long __attribute__((unused)) argl, long ret)
+ {
+@@ -373,7 +394,7 @@ long BIO_debug_callback(BIO *bio, int cmd, const char __attribute__((unused)) *a
+ 
+ 	return (r);
+ }
+-
++#endif /* !ENABLE_WOLFSSL */
+ 
+ /* Convert a fingerprint to printable data. The  conversion is carried out
+  * according IETF I-D syslog-transport-tls-12. The fingerprint string is
+@@ -417,10 +438,17 @@ osslGlblInit(void)
+ 	const char *caFile, *certFile, *keyFile;
+ 
+ 	/* Setup OpenSSL library */
++	#ifndef ENABLE_WOLFSSL
+ 	if((opensslh_THREAD_setup() == 0) || !SSL_library_init()) {
++	#else
++	if(!SSL_library_init()) {
++	#endif
+ 		LogError(0, RS_RET_NO_ERRCODE, "Error: OpenSSL initialization failed!");
+ 	}
+ 
++	#if defined(ENABLE_WOLFSSL) && defined(DEBUG_WOLFSSL)
++	wolfSSL_Debugging_ON();
++	#endif
+ 	/* Load readable error strings */
+ 	SSL_load_error_strings();
+ 	ERR_load_BIO_strings();
+@@ -452,8 +480,16 @@ osslGlblInit(void)
+ 		bHaveKey = 1;
+ 	}
+ 
++/* wolfSSL will use TLS 1.3 if it's compiled in and we call SSLv23_method. This
++ * is at odds with the fact that rsyslog allows usage of anonymous cipher
++ * suites, which were deprecated in TLS 1.3. To continue to allow these suites,
++ * we explicitly request TLS 1.2 here. */
++#ifdef ENABLE_WOLFSSL
++	ctx = SSL_CTX_new(TLSv1_2_method());
++#else
+ 	/* Create main CTX Object */
+ 	ctx = SSL_CTX_new(SSLv23_method());
++#endif
+ 	if(bHaveCA == 1 && SSL_CTX_load_verify_locations(ctx, caFile, NULL) != 1) {
+ 		LogError(0, RS_RET_TLS_CERT_ERR, "Error: CA certificate could not be accessed. "
+ 				"Check at least: 1) file path is correct, 2) file exist, "
+@@ -501,6 +537,11 @@ finalize_it:
+ static rsRetVal
+ osslAnonInit(void)
+ {
++	#ifdef ENABLE_WOLFSSL
++	DH* dh;
++	BIGNUM* p;
++	BIGNUM* g;
++	#endif
+ 	DEFiRet;
+ 	pthread_mutex_lock(&anonInit_mut);
+ 	if (bAnonInit == 1) {
+@@ -509,7 +550,19 @@ osslAnonInit(void)
+ 	}
+ 	dbgprintf("osslAnonInit Init Anon OpenSSL helpers\n");
+ 
+-	#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++	#ifdef ENABLE_WOLFSSL
++	/* wolfSSL doesn't have support for ECDH anonymous ciphers, just DH.
++	 * Accordingly, we need to generate an ephemeral DH key. This is done using
++	 * the parameters from RFC3526 prime 2048 (id 14).*/
++	dh = DH_new();
++	p = get_rfc3526_prime_2048(NULL);
++	g = BN_new();
++	BN_set_word(g, 2);
++	DH_set0_pqg(dh, p, NULL, g);
++	DH_generate_key(dh);
++	SSL_CTX_set_tmp_dh(ctx, dh);
++	DH_free(dh);
++	#elif OPENSSL_VERSION_NUMBER >= 0x10002000L
+ 	/* Enable Support for automatic EC temporary key parameter selection. */
+ 	SSL_CTX_set_ecdh_auto(ctx, 1);
+ 	#else
+@@ -636,8 +689,21 @@ osslInitSession(nsd_ossl_t *pThis) /* , nsd_ossl_t *pServer) */
+ 	}
+ 
+ 	if (bAnonInit == 1) { /* no mutex needed, read-only after init */
++		#ifdef ENABLE_WOLFSSL
++		if (bHaveCert == 0) {
++			/* To get wolfSSL to use the anonymous ciphers, they need to be
++			 * moved to the front of the list (or be the only items in the
++			 * list). But, we only want to do this if we don't have a cert.
++			 * Otherwise, we want to prefer non-anonymous ciphers. OpenSSL
++			 * defaults to anon ciphers when a cert is not available. */
++			strncpy(pristringBuf, "ADH-AES256-GCM-SHA384:ADH-AES128-SHA",
++				sizeof(pristringBuf));
++		}
++		else {
++			strncpy(pristringBuf, "ALL", sizeof(pristringBuf));
++		}
+ 		/* Allow ANON Ciphers */
+-		#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++		#elif OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 		 /* NOTE: do never use: +eNULL, it DISABLES encryption! */
+ 		strncpy(pristringBuf, "ALL:+COMPLEMENTOFDEFAULT:+ADH:+ECDH:+aNULL@SECLEVEL=0",
+ 			sizeof(pristringBuf));
+@@ -657,8 +723,10 @@ osslInitSession(nsd_ossl_t *pThis) /* , nsd_ossl_t *pServer) */
+ 	client = BIO_new_socket(pPtcp->sock, BIO_CLOSE /*BIO_NOCLOSE*/);
+ 	dbgprintf("osslInitSession: Init client BIO[%p] done\n", (void *)client);
+ 
++	#ifndef ENABLE_WOLFSSL
+ 	/* Set debug Callback for client BIO as well! */
+ 	BIO_set_callback(client, BIO_debug_callback);
++	#endif
+ 
+ /* TODO: still needed? Set to NON blocking ! */
+ BIO_set_nbio( client, 1 );
+@@ -1392,7 +1460,7 @@ osslPostHandshakeCheck(nsd_ossl_t *pNsd)
+ 	if (SSL_get_shared_ciphers(pNsd->ssl,szDbg, sizeof szDbg) != NULL)
+ 		dbgprintf("osslPostHandshakeCheck: Debug Shared ciphers = %s\n", szDbg);
+ 
+-	#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++	#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(ENABLE_WOLFSSL)
+ 	if(SSL_get_shared_curve(pNsd->ssl, -1) == 0) {
+ 		LogError(0, RS_RET_NO_ERRCODE, "nsd_ossl:"
+ 		"No shared curve between syslog client and server.");
+@@ -1731,7 +1799,9 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
+ 	nsd_ossl_t* pThis = (nsd_ossl_t*) pNsd;
+ 	nsd_ptcp_t* pPtcp = (nsd_ptcp_t*) pThis->pTcp;
+ 	BIO *conn;
++#ifndef ENABLE_WOLFSSL
+ 	char pristringBuf[4096];
++#endif
+ 
+ 	ISOBJ_TYPE_assert(pThis, nsd_ossl);
+ 	assert(port != NULL);
+@@ -1772,6 +1842,11 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
+ 		}
+ 	}
+ 
++	/* If using wolfSSL, nothing needs to be done for the client side of anon
++	 * connections, aside from compiling libwolfssl with -DHAVE_ANON. The anon
++	 * ciphers will already be available and don't need to be enabled at
++	 * runtime. */
++	#ifndef ENABLE_WOLFSSL
+ 	if (bAnonInit == 1) { /* no mutex needed, read-only after init */
+ 		/* Allow ANON Ciphers */
+ 		#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+@@ -1789,9 +1864,12 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
+ 			ABORT_FINALIZE(RS_RET_SYS_ERR);
+ 		}
+ 	}
++	#endif
+ 
++	#ifndef ENABLE_WOLFSSL
+ 	/* Set debug Callback for client BIO as well! */
+ 	BIO_set_callback(conn, BIO_debug_callback);
++	#endif
+ 
+ /* TODO: still needed? Set to NON blocking ! */
+ BIO_set_nbio( conn, 1 );
+@@ -1838,7 +1916,7 @@ SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unus
+ 		RETiRet;
+ 	} else {
+ 		dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(ENABLE_WOLFSSL)
+ 		char *pCurrentPos;
+ 		char *pNextPos;
+ 		char *pszCmd;
+diff --git a/runtime/nsdsel_ossl.c b/runtime/nsdsel_ossl.c
+index 8f6a7927c..2c6284e95 100644
+--- a/runtime/nsdsel_ossl.c
++++ b/runtime/nsdsel_ossl.c
+@@ -28,6 +28,9 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <sys/select.h>
++#ifdef ENABLE_WOLFSSL
++#include <wolfssl/options.h>
++#endif
+ #include <openssl/ssl.h>
+ #include <openssl/bio.h>
+ 
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index fbe84ab04..6ad045257 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -2725,10 +2725,16 @@ tcpflood_CPPFLAGS += $(GNUTLS_CFLAGS)
+ tcpflood_LDADD += $(GNUTLS_LIBS)
+ endif
+ if ENABLE_OPENSSL
++if ENABLE_WOLFSSL
++tcpflood_CFLAGS += $(WOLFSSL_CFLAGS)
++tcpflood_CPPFLAGS += $(WOLFSSL_CFLAGS)
++tcpflood_LDADD += $(WOLFSSL_LIBS)
++else
+ tcpflood_CFLAGS += $(OPENSSL_CFLAGS)
+ tcpflood_CPPFLAGS += $(OPENSSL_CFLAGS)
+ tcpflood_LDADD += $(OPENSSL_LIBS)
+ endif
++endif
+ 
+ minitcpsrv_SOURCES = minitcpsrvr.c
+ minitcpsrv_LDADD = $(SOL_LIBS)
+diff --git a/tests/tcpflood.c b/tests/tcpflood.c
+index 4ad2a5c58..b02572a6f 100644
+--- a/tests/tcpflood.c
++++ b/tests/tcpflood.c
+@@ -123,11 +123,17 @@
+ #	endif
+ #endif
+ #ifdef ENABLE_OPENSSL
++#ifdef ENABLE_WOLFSSL
++	#include <wolfssl/options.h>
++#endif
+ 	#include <openssl/ssl.h>
+ 	#include <openssl/x509v3.h>
+ 	#include <openssl/err.h>
+ 	#include <openssl/engine.h>
+ 
++#ifdef ENABLE_WOLFSSL
++	#define RSYSLOG_X509_NAME_oneline(X509CERT) X509_get_subject_name(X509CERT)
++#else
+ 	/* OpenSSL API differences */
+ 	#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+ 		#define RSYSLOG_X509_NAME_oneline(X509CERT) X509_get_subject_name(X509CERT)
+@@ -141,6 +147,7 @@
+ 		#define RSYSLOG_BIO_number_written(SSLBIO) SSLBIO->num
+ 	#endif
+ 
++#endif /* ENABLE_WOLFSSL */
+ #endif
+ 
+ char *test_rs_strerror_r(int errnum, char *buf, size_t buflen) {
+@@ -1025,6 +1032,7 @@ runTests(void)
+  * alorbach, 2018-06-11
+  */
+ 
++#ifndef ENABLE_WOLFSSL
+ long BIO_debug_callback(BIO *bio, int cmd, const char __attribute__((unused)) *argp,
+ 			int argi, long __attribute__((unused)) argl, long ret)
+ {
+@@ -1100,6 +1108,7 @@ long BIO_debug_callback(BIO *bio, int cmd, const char __attribute__((unused)) *a
+ 
+ 	return (r);
+ }
++#endif /* !ENABLE_WOLFSSL */
+ 
+ void osslLastSSLErrorMsg(int ret, SSL *ssl, const char* pszCallSource)
+ {
+@@ -1189,13 +1198,25 @@ initTLS(void)
+ 		exit(1);
+ 	}
+ 
++#if defined(ENABLE_WOLFSSL) && defined(DEBUG_WOLFSSL)
++	wolfSSL_Debugging_ON();
++#endif
++
+ 	/* Load readable error strings */
+ 	SSL_load_error_strings();
+ 	ERR_load_BIO_strings();
+ 	ERR_load_crypto_strings();
+ 
++/* wolfSSL will use TLS 1.3 if it's compiled in and we call SSLv23_method. This
++ * is at odds with the fact that rsyslog allows usage of anonymous cipher
++ * suites, which were deprecated in TLS 1.3. To continue to allow these suites,
++ * we explicitly request TLS 1.2 here. */
++#ifdef ENABLE_WOLFSSL
++	ctx = SSL_CTX_new(TLSv1_2_method());
++#else
+ 	/* Create main CTX Object */
+ 	ctx = SSL_CTX_new(SSLv23_method());
++#endif
+ 
+ 	if(tlsCAFile != NULL && SSL_CTX_load_verify_locations(ctx, tlsCAFile, NULL) != 1) {
+ 		printf("tcpflood: Error, Failed loading CA certificate"
+@@ -1224,7 +1245,7 @@ initTLS(void)
+ 
+ 	/* Check for Custom Config string */
+ 	if (customConfig != NULL){
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(ENABLE_WOLFSSL)
+ 	char *pCurrentPos;
+ 	char *pNextPos;
+ 	char *pszCmd;
+@@ -1349,10 +1370,12 @@ initTLSSess(int i)
+ 	//	printf("initTLSSess: Init client BIO[%p] done\n", (void *)client);
+ 	}
+ 
++#ifndef ENABLE_WOLFSSL
+ 	if(tlsLogLevel > 0) {
+ 		/* Set debug Callback for client BIO as well! */
+ 		BIO_set_callback(client, BIO_debug_callback);
+ 	}
++#endif
+ 
+ 	/* Blocking socket */
+ 	BIO_set_nbio( client, 0 );

--- a/recipes-extended/rsyslog/rsyslog_8.2106.0.bbappend
+++ b/recipes-extended/rsyslog/rsyslog_8.2106.0.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://rsyslog-8.2106.0.patch"
+PACKAGECONFIG_remove = "gnutls libgcrypt"
+DEPENDS += "wolfssl"
+EXTRA_OECONF += "--with-wolfssl=${STAGING_EXECPREFIXDIR}"

--- a/recipes-extended/rsyslog/wolfssl_%.bbappend
+++ b/recipes-extended/rsyslog/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-rsyslog"

--- a/recipes-protocols/net-snmp/files/net-snmp-5.9.patch
+++ b/recipes-protocols/net-snmp/files/net-snmp-5.9.patch
@@ -1,0 +1,333 @@
+From 12fe930f15630d1294daebf32a9a7734f2bbbc81 Mon Sep 17 00:00:00 2001
+From: Juliusz Sosinowicz <juliusz@wolfssl.com>
+Date: Mon, 12 Jul 2021 15:57:17 +0200
+Subject: [PATCH] wolfSSL patch
+
+Changes:
+- `configure.d/*`: add the `--with-wolfssl` option
+- The  `wolfssl/options.h` header is included by defining the `EXTERNAL_OPTS_OPENVPN` macro
+- `asn1.h`: some of the `ASN_*` tags are already defined by wolfSSL
+- `cert_util.h`: check for wolfSSL headers
+- `snmp_debug.c`: enable wolfSSL debug logging
+- `snmpDTLSUDPDomain.c`: wolfSSL does not provide callbacks for cookie generation
+
+Testing with publicly available server: https://gambitcomm.blogspot.com/2017/02/publically-accessible-simulated-snmp.html
+
+wolfSSL
+```
+./autogen.sh
+./configure --enable-net-snmp
+make
+make install
+```
+
+net-snmp
+```
+patch -p1 < <path/to/patch/file>
+autoreconf -ivf
+./configure --with-wolfssl
+make
+make test
+```
+---
+ configure.d/config_os_functions        |  2 ++
+ configure.d/config_os_libs2            | 38 ++++++++++++++++++++++++++
+ configure.d/config_os_misc2            |  7 +++++
+ configure.d/config_project_with_enable | 30 ++++++++++++++++++--
+ include/net-snmp/library/asn1.h        | 11 +++++++-
+ include/net-snmp/library/cert_util.h   |  4 +--
+ snmplib/cert_util.c                    |  2 ++
+ snmplib/snmp_debug.c                   | 13 +++++++++
+ snmplib/transports/snmpDTLSUDPDomain.c | 10 +++++++
+ 9 files changed, 112 insertions(+), 5 deletions(-)
+
+diff --git a/configure.d/config_os_functions b/configure.d/config_os_functions
+index 889e2c472..76c2acc29 100644
+--- a/configure.d/config_os_functions
++++ b/configure.d/config_os_functions
+@@ -348,6 +348,7 @@ esac
+ AC_DEFINE_UNQUOTED([NETSNMP_PRIz], ["$netsnmp_PRIz"],
+                    [Size prefix to use to printf a size_t or ssize_t])
+ 
++if test "x$trywolfssl" = "xno"; then
+ # check to see if the openssl is good enough for DTLS
+ # (BIO_dgram_get_peer is a macro, not a true function)
+ if echo " $transport_result_list " | $GREP "DTLS" > /dev/null; then
+@@ -368,4 +369,5 @@ if echo " $transport_result_list " | $GREP "DTLS" > /dev/null; then
+        AC_MSG_RESULT(yes)
+     )
+ fi
++fi
+ 
+diff --git a/configure.d/config_os_libs2 b/configure.d/config_os_libs2
+index 9fd51f75b..883b2a92d 100644
+--- a/configure.d/config_os_libs2
++++ b/configure.d/config_os_libs2
+@@ -374,6 +374,44 @@ if test "x$tryopenssl" != "xno" -a "x$tryopenssl" != "xinternal"; then
+             SSHPROG=yes
+         fi
+     fi
++elif test "x$trywolfssl" != "xno"; then
++    CRYPTO="wolfssl"
++    LIBCRYPTO="-l${CRYPTO}"
++    LIBS="$LIBCRYPTO"
++    AC_DEFINE(HAVE_AES_CFB128_ENCRYPT, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_EVP_SHA224, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_EVP_SHA384, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_EVP_MD_CTX_CREATE, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_EVP_MD_CTX_DESTROY, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_EVP_MD_CTX_NEW, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_EVP_MD_CTX_FREE, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_DH_SET0_PQG, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_DH_GET0_PQG, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_DH_GET0_KEY, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_ASN1_STRING_GET0_DATA, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_X509_NAME_ENTRY_GET_OBJECT, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_X509_NAME_ENTRY_GET_DATA, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_X509_GET_SIGNATURE_NID, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_TLS_METHOD, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_TLSV1_METHOD, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_DTLS_METHOD, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_DTLSV1_METHOD, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_SSL_LIBRARY_INIT, 1, [Defined as macro in wolfSSL])
++    AC_DEFINE(HAVE_SSL_LOAD_ERROR_STRINGS, 1, [Defined as macro in wolfSSL])
++    if echo " $transport_result_list " | $GREP "DTLS" > /dev/null; then
++        AC_DEFINE(HAVE_LIBSSL_DTLS, 1, [wolfSSL supports DTLS])
++    fi
++    if echo " $transport_result_list " | $GREP "TLS" > /dev/null; then
++        AC_DEFINE(HAVE_LIBSSL, 1, [wolfSSL supports SSL/TLS])
++    fi
++    if echo " $transport_result_list " | $GREP " SSH " > /dev/null; then
++    AC_CHECK_LIB(ssh2, libssh2_session_startup,
++            AC_DEFINE(HAVE_LIBSSH2, 1,
++                [Define to 1 if you have the `ssh2' library (-lssh2).])
++            LIBCRYPTO=" -lssh2 $LIBCRYPTO",
++            AC_MSG_ERROR([The SSH transport requires the libssh2 library to be available]),)
++        SSHPROG=yes
++    fi
+ elif test "x$askedpkcs" = "xyes"; then
+     AC_CHECK_LIB(pkcs11, C_Initialize,
+         AC_DEFINE(HAVE_LIBPKCS11)
+diff --git a/configure.d/config_os_misc2 b/configure.d/config_os_misc2
+index be0bccec0..b427bed2e 100644
+--- a/configure.d/config_os_misc2
++++ b/configure.d/config_os_misc2
+@@ -72,6 +72,13 @@ elif test "x$useopenssl" != "xno" ; then
+     AC_DEFINE(NETSNMP_USE_OPENSSL)
+     LNETSNMPLIBS="$LNETSNMPLIBS $LIBCRYPTO"
+     AC_MSG_RESULT(OpenSSL Support)
++elif test "x$trywolfssl" != "xno"; then
++    authmodes="MD5 SHA1 SHA224 SHA256 SHA384 SHA512"
++    encrmodes="DES AES"
++    AC_DEFINE(NETSNMP_USE_OPENSSL)
++    AC_DEFINE(NETSNMP_USE_WOLFSSL, 1, [Use wolfSSL])
++    LNETSNMPLIBS="$LNETSNMPLIBS $LIBCRYPTO"
++    AC_MSG_RESULT(wolfSSL Support)
+ elif test "x$usepkcs" != "xno" ; then
+     authmodes="MD5 SHA1"
+     if test "x$enable_privacy" != "xno" ; then
+diff --git a/configure.d/config_project_with_enable b/configure.d/config_project_with_enable
+index cdf56deb6..d4db22871 100644
+--- a/configure.d/config_project_with_enable
++++ b/configure.d/config_project_with_enable
+@@ -72,14 +72,40 @@ NETSNMP_ARG_WITH(rsaref,
+     fi,
+ )
+ 
+-tryopenssl=defaultyes
++trywolfssl=no
++wolfpath="/usr/local"
++NETSNMP_ARG_WITH(wolfssl,
++[  --with-wolfssl=PATH             Look for wolfssl in PATH/lib.],
++    if test "x$withval" = "xyes"; then
++      trywolfssl=yes
++    else
++      trywolfssl=yes
++      wolfpath=$withval
++    fi,
++)
++if test "x$trywolfssl" = "xyes"; then
++	  if test -d $wolfpath/lib && test -d $wolfpath/include/wolfssl ; then
++        LDFLAGS="-L$wolfpath/lib $LDFLAGS"
++        CPPFLAGS="-I$wolfpath/include -I$wolfpath/include/wolfssl -DEXTERNAL_OPTS_OPENVPN $CPPFLAGS"
++	  else
++	    AC_MSG_ERROR([Cannot find wolfSSL in $wolfpath.])
++	  fi
++fi
++
++if test "x$trywolfssl" = "xyes"; then
++      tryopenssl=no
++else
++      tryopenssl=defaultyes
++fi
+ askedopenssl=no
+ aes_capable=no
+ NETSNMP_ARG_WITH(openssl,
+ [  --with-openssl=PATH             Look for openssl in PATH/lib,
+                                   or PATH may be "internal" to build with
+                                   minimal copied OpenSSL code for USM only.],
+-    if test "x$withval" = "xyes"; then
++    if test "x$trywolfssl" = "xyes"; then
++	  AC_MSG_ERROR([Cannot specify both OpenSSL and wolfSSL])
++    elif test "x$withval" = "xyes"; then
+       tryopenssl=yes
+       askedopenssl=yes
+     elif test "x$withval" = "xinternal"; then
+diff --git a/include/net-snmp/library/asn1.h b/include/net-snmp/library/asn1.h
+index 227ee7849..398030fd1 100644
+--- a/include/net-snmp/library/asn1.h
++++ b/include/net-snmp/library/asn1.h
+@@ -3,6 +3,10 @@
+ 
+ #include <net-snmp/library/oid.h>
+ 
++#ifdef NETSNMP_USE_WOLFSSL
++#include <wolfssl/wolfcrypt/asn.h>
++#endif
++
+ #ifdef __cplusplus
+ extern          "C" {
+ #endif
+@@ -51,18 +55,23 @@ SOFTWARE.
+ 
+ #define OID_LENGTH(x)  (sizeof(x)/sizeof(oid))
+ 
+-
++#ifndef NETSNMP_USE_WOLFSSL
+ #define ASN_BOOLEAN	    0x01U
+ #define ASN_INTEGER	    0x02U
++#endif
+ #define ASN_BIT_STR	    0x03U
+ #define ASN_OCTET_STR	    0x04U
+ #define ASN_NULL	    0x05U
++#ifndef NETSNMP_USE_WOLFSSL
+ #define ASN_OBJECT_ID	    0x06U
+ #define ASN_SEQUENCE	    0x10U
+ #define ASN_SET		    0x11U
++#endif
+ 
+ #define ASN_UNIVERSAL	    0x00U
++#ifndef NETSNMP_USE_WOLFSSL
+ #define ASN_APPLICATION     0x40U
++#endif
+ #define ASN_CONTEXT	    0x80U
+ #define ASN_PRIVATE	    0xC0U
+ 
+diff --git a/include/net-snmp/library/cert_util.h b/include/net-snmp/library/cert_util.h
+index 80e2a19f9..268376c5b 100644
+--- a/include/net-snmp/library/cert_util.h
++++ b/include/net-snmp/library/cert_util.h
+@@ -2,10 +2,10 @@
+ 
+ #if defined(NETSNMP_USE_OPENSSL) && defined(HAVE_LIBSSL)
+ 
+-#ifndef HEADER_SSL_H
++#if !(defined(HEADER_SSL_H) || defined(WOLFSSL_OPENSSL_H_))
+ #error "must include <openssl/ssl.h> before cert_util.h"
+ #endif
+-#ifndef HEADER_X509_H
++#if !(defined(HEADER_X509_H) || defined(WOLFSSL_OPENSSL_509_H_))
+ #error "must include <openssl/x509.h> before cert_util.h"
+ #endif
+ 
+diff --git a/snmplib/cert_util.c b/snmplib/cert_util.c
+index e7b7114f6..d230dfe2f 100644
+--- a/snmplib/cert_util.c
++++ b/snmplib/cert_util.c
+@@ -45,6 +45,7 @@ netsnmp_feature_child_of(tls_fingerprint_build, cert_util_all);
+ #if HAVE_STDLIB_H
+ #include <stdlib.h>
+ #endif
++#include <stddef.h>
+ 
+ #if HAVE_STRING_H
+ #include <string.h>
+@@ -87,6 +88,7 @@ netsnmp_feature_child_of(tls_fingerprint_build, cert_util_all);
+ #include <net-snmp/library/read_config.h>
+ 
+ #include <openssl/ssl.h>
++#include <openssl/pem.h>
+ #include <openssl/err.h>
+ #include <openssl/x509v3.h>
+ #include <net-snmp/library/cert_util.h>
+diff --git a/snmplib/snmp_debug.c b/snmplib/snmp_debug.c
+index 08726574c..dc4a3dcd9 100644
+--- a/snmplib/snmp_debug.c
++++ b/snmplib/snmp_debug.c
+@@ -680,9 +680,22 @@ snmp_debug_shutdown(void)
+ 
+ #endif /* NETSNMP_NO_DEBUGGING */
+ 
++#ifdef NETSNMP_USE_WOLFSSL
++static void logMsg(const int logLevel, const char* const msg)
++{
++    (void)logLevel;
++    DEBUGMSGTL(("snmp_openssl", msg, "\n"));
++}
++#endif
++
+ void
+ snmp_debug_init(void)
+ {
++
++#ifdef NETSNMP_USE_WOLFSSL
++    wolfSSL_Debugging_ON();
++    wolfSSL_SetLoggingCb(logMsg);
++#endif
+     register_prenetsnmp_mib_handler("snmp", "doDebugging",
+                                     debug_config_turn_on_debugging, NULL,
+                                     "(1|0)");
+diff --git a/snmplib/transports/snmpDTLSUDPDomain.c b/snmplib/transports/snmpDTLSUDPDomain.c
+index c7032e6cb..541d536c5 100644
+--- a/snmplib/transports/snmpDTLSUDPDomain.c
++++ b/snmplib/transports/snmpDTLSUDPDomain.c
+@@ -121,12 +121,18 @@ static bio_cache *biocache = NULL;
+ 
+ static int openssl_addr_index = 0;
+ 
++#ifndef SECOND_APPVERIFY_COOKIE_CB_ARG_QUALIFIER
++#define SECOND_APPVERIFY_COOKIE_CB_ARG_QUALIFIER
++#endif
++#ifndef NETSNMP_USE_WOLFSSL
++/* no cookie callbacks in wolfSSL */
+ static int netsnmp_dtls_verify_cookie(SSL *ssl,
+                                       SECOND_APPVERIFY_COOKIE_CB_ARG_QUALIFIER
+                                       unsigned char *cookie,
+                                       unsigned int cookie_len);
+ static int netsnmp_dtls_gen_cookie(SSL *ssl, unsigned char *cookie,
+                                    unsigned int *cookie_len);
++#endif
+ 
+ /* this stores remote connections in a list to search through */
+ /* XXX: optimize for searching */
+@@ -337,10 +343,12 @@ start_new_cached_connection(netsnmp_transport *t,
+             DIEHERE("failed to create the SSL Context");
+         }
+ 
++#ifndef NETSNMP_USE_WOLFSSL
+         /* turn on cookie exchange */
+         /* Set DTLS cookie generation and verification callbacks */
+         SSL_CTX_set_cookie_generate_cb(ctx, netsnmp_dtls_gen_cookie);
+         SSL_CTX_set_cookie_verify_cb(ctx, netsnmp_dtls_verify_cookie);
++#endif
+ 
+         tlsdata->ssl = SSL_new(ctx);
+     }
+@@ -1692,6 +1700,7 @@ netsnmp_dtlsudp_ctor(void)
+ int cookie_initialized=0;
+ unsigned char cookie_secret[NETSNMP_COOKIE_SECRET_LENGTH];
+ 
++#ifndef NETSNMP_USE_WOLFSSL
+ int netsnmp_dtls_gen_cookie(SSL *ssl, unsigned char *cookie,
+                             unsigned int *cookie_len)
+ {
+@@ -1873,5 +1882,6 @@ int netsnmp_dtls_verify_cookie(SSL *ssl,
+ 
+     return rc;
+ }
++#endif
+ 
+ #endif /* HAVE_LIBSSL_DTLS */
+-- 
+2.25.1
+

--- a/recipes-protocols/net-snmp/net-snmp_5.9.bbappend
+++ b/recipes-protocols/net-snmp/net-snmp_5.9.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://net-snmp-5.9.patch"
+DEPENDS_remove = "openssl"
+DEPENDS += "wolfssl"
+EXTRA_OECONF += "--with-wolfssl=${STAGING_EXECPREFIXDIR}"

--- a/recipes-protocols/net-snmp/wolfssl_%.bbappend
+++ b/recipes-protocols/net-snmp/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-net-snmp"

--- a/recipes-support/libssh2/files/libssh2-1.9.0.patch
+++ b/recipes-support/libssh2/files/libssh2-1.9.0.patch
@@ -1,0 +1,183 @@
+diff --git a/Makefile.wolfSSL.inc b/Makefile.wolfSSL.inc
+new file mode 100644
+index 0000000..24fed51
+--- /dev/null
++++ b/Makefile.wolfSSL.inc
+@@ -0,0 +1,3 @@
++CRYPTO_CSOURCES = openssl.c
++CRYPTO_HHEADERS = openssl.h
++CRYPTO_LTLIBS = -lwolfssl
+diff --git a/configure.ac b/configure.ac
+index fe5054a..3534959 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -102,6 +102,26 @@ AC_ARG_WITH([crypto],
+   use_crypto=auto
+ )
+ 
++AC_ARG_WITH([wolfssl],
++  AC_HELP_STRING([--with-wolfssl],[Use wolfSSL for crypto.]),
++  [
++    wolfssl_path_set=yes
++    wolfssl_path=$withval
++    use_crypto=wolfssl
++  ],
++  [
++    wolfssl_path_set=no
++  ]
++)
++
++# wolfSSL uses a bespoke approach rather than adding a case stanza to
++# LIBSSH2_CHECK_CRYPTO. This is because AC_LIB_HAVE_LINKFLAGS will instruct the
++# linker to embed the rpath to libwolfssl.so in libssh2. This causes problems
++# when, for example, you're cross-compiling in a Yocto context and the path to
++# libwolfssl at build time will not be the same as the one needed at runtime.
++# One can use --disable-rpath to get around this, but the result is that the
++# compiler is just given the direct path to libwolfssl.so on the build host,
++# which has the same problem.
+ case "${use_crypto}" in
+   auto|m4_set_contents([crypto_backends], [|]))
+     m4_set_map([crypto_backends], [LIBSSH2_CHECK_CRYPTO])
+@@ -109,6 +129,25 @@ case "${use_crypto}" in
+   yes|"")
+     crypto_errors="No crypto backend specified!"
+     ;;
++  wolfssl)
++    if test "$wolfssl_path_set" = "no"; then
++      AC_MSG_ERROR([Unable to find wolfssl, must provide path with --with-wolfssl=PATH.])
++    else
++      AC_CHECK_HEADER([wolfssl/options.h])
++      if test "$ac_cv_header_wolfssl_options_h" = "yes"; then
++        AC_DEFINE(LIBSSH2_OPENSSL, 1, [Use openssl])
++        AC_DEFINE(LIBSSH2_WOLFSSL, 1, [Use $1])
++        AC_DEFINE(HAVE_EVP_AES_128_CTR)
++        CPPFLAGS="$CPPFLAGS${CPPFLAGS:+ }-I$wolfssl_path/include -I$wolfssl_path/include/wolfssl"
++        LDFLAGS="$LDFLAGS${LDFLAGS:+ }-L$wolfssl_path/lib"
++        LIBSREQUIRED="$LIBSREQUIRED${LIBSREQUIRED:+ }libwolfssl"
++        found_crypto=wolfssl
++        AM_CONDITIONAL([WOLFSSL], [true])
++      else
++        AC_MSG_ERROR([Unable to find wolfssl header options.h.])
++      fi
++    fi
++    ;;
+   *)
+     crypto_errors="Unknown crypto backend '${use_crypto}' specified!"
+     ;;
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 31d58ed..46cb88c 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -5,6 +5,9 @@ AUTOMAKE_OPTIONS = foreign nostdinc
+ if OPENSSL
+ include ../Makefile.OpenSSL.inc
+ endif
++if WOLFSSL
++include ../Makefile.wolfSSL.inc
++endif
+ if LIBGCRYPT
+ include ../Makefile.libgcrypt.inc
+ endif
+diff --git a/src/openssl.c b/src/openssl.c
+index 04d5ec2..3d5aabb 100644
+--- a/src/openssl.c
++++ b/src/openssl.c
+@@ -426,6 +426,13 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
+     ret = EVP_Cipher(*ctx, buf, block, blocksize);
+ #else
+     ret = EVP_Cipher(ctx, buf, block, blocksize);
++#endif
++#ifdef LIBSSH2_WOLFSSL
++    /* wolfSSL's implementation of EVP_Cipher returns the number of encrypted/
++     * decrypted bytes on success and -1 on failure. */
++    if (ret == (int)blocksize) {
++        ret = 1;
++    }
+ #endif
+     if(ret == 1) {
+         memcpy(block, buf, blocksize);
+diff --git a/src/openssl.h b/src/openssl.h
+index 15518e0..f0c7e99 100644
+--- a/src/openssl.h
++++ b/src/openssl.h
+@@ -37,6 +37,39 @@
+  * OF SUCH DAMAGE.
+  */
+ 
++#ifdef LIBSSH2_WOLFSSL
++
++#include <wolfssl/options.h>
++#include <openssl/ecdh.h>
++
++#ifdef NO_DSA
++#define OPENSSL_NO_DSA
++#endif
++
++#ifdef NO_MD5
++#define OPENSSL_NO_MD5
++#endif
++
++#ifndef WOLFSSL_RIPEMD
++#define OPENSSL_NO_RIPEMD
++#endif
++
++#ifdef NO_RC4
++#define OPENSSL_NO_RC4
++#endif
++
++#ifdef NO_DES3
++#define OPENSSL_NO_DES
++#endif
++
++/* wolfSSL doesn't support Blowfish or CAST. */
++#define OPENSSL_NO_BF
++#define OPENSSL_NO_CAST
++/* wolfSSL has no engine framework. */
++#define OPENSSL_NO_ENGINE
++
++#endif /* LIBSSH2_WOLFSSL */
++
+ #include <openssl/opensslconf.h>
+ #include <openssl/sha.h>
+ #include <openssl/rsa.h>
+@@ -55,8 +88,10 @@
+ #include <openssl/pem.h>
+ #include <openssl/rand.h>
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+-    !defined(LIBRESSL_VERSION_NUMBER)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && \
++    !defined(LIBRESSL_VERSION_NUMBER)) || defined(LIBSSH2_WOLFSSL)
++/* For wolfSSL, whether the structs are truly opaque or not, it's best to not
++ * rely on their internal data members being exposed publicly. */
+ # define HAVE_OPAQUE_STRUCTS 1
+ #endif
+ 
+@@ -78,14 +113,15 @@
+ # define LIBSSH2_ECDSA 1
+ #endif
+ 
++/* wolfSSL's OpenSSL compatibility layer doesn't have support for all the
++ * necessary ED25519 functions, yet. */
+ #if OPENSSL_VERSION_NUMBER >= 0x10101000L && \
+-!defined(LIBRESSL_VERSION_NUMBER)
++    !defined(LIBRESSL_VERSION_NUMBER) && !defined(LIBSSH2_WOLFSSL)
+ # define LIBSSH2_ED25519 1
+ #else
+ # define LIBSSH2_ED25519 0
+ #endif
+ 
+-
+ #ifdef OPENSSL_NO_MD5
+ # define LIBSSH2_MD5 0
+ #else
+@@ -101,7 +137,8 @@
+ #define LIBSSH2_HMAC_SHA256 1
+ #define LIBSSH2_HMAC_SHA512 1
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00907000L && !defined(OPENSSL_NO_AES)
++#if (OPENSSL_VERSION_NUMBER >= 0x00907000L && !defined(OPENSSL_NO_AES)) || \
++    (defined(LIBSSH2_WOLFSSL) && defined(WOLFSSL_AES_COUNTER))
+ # define LIBSSH2_AES_CTR 1
+ # define LIBSSH2_AES 1
+ #else

--- a/recipes-support/libssh2/libssh2_1.9.0.bbappend
+++ b/recipes-support/libssh2/libssh2_1.9.0.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://libssh2-1.9.0.patch"
+PACKAGECONFIG_remove = "openssl"
+DEPENDS += "wolfssl"
+EXTRA_OECONF += "--with-wolfssl=${STAGING_EXECPREFIXDIR}"

--- a/recipes-support/libssh2/wolfssl_%.bbappend
+++ b/recipes-support/libssh2/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-libssh2"

--- a/recipes-support/strongswan/strongswan_5.9.4.bbappend
+++ b/recipes-support/strongswan/strongswan_5.9.4.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-wolfssl"

--- a/recipes-support/strongswan/wolfssl_%.bbappend
+++ b/recipes-support/strongswan/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-strongswan"

--- a/recipes-support/tcpdump/files/tcpdump-4.9.3.patch
+++ b/recipes-support/tcpdump/files/tcpdump-4.9.3.patch
@@ -1,0 +1,167 @@
+diff --git a/configure.ac b/configure.ac
+index 56e2a62..dd14e33 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -864,6 +864,33 @@ AC_LBL_SOCKADDR_SA_LEN
+ 
+ AC_LBL_UNALIGNED_ACCESS
+ 
++AC_ARG_WITH(wolfssl,
++    AS_HELP_STRING([--with-wolfssl]=DIR,
++		   [use wolfSSL (located in directory DIR) @<:@default=no@:>@]),
++[
++	CPPFLAGS="$CPPFLAGS -I${withval}/include/wolfssl -I${withval}/include/"
++	LDFLAGS="$LDFLAGS -L${withval}/lib"
++	LIBS="$LIBS -lwolfssl"
++	USE_WOLFSSL=yes],
++[
++	USE_WOLFSSL=no
++])
++
++if test $USE_WOLFSSL = yes
++then
++    AC_CHECK_HEADER([wolfssl/options.h])
++    if test $ac_cv_header_wolfssl_options_h = yes
++    then
++        AC_DEFINE(HAVE_WOLFSSL, 1, [define if you're using wolfSSL])
++        AC_DEFINE(HAVE_EVP_CIPHER_CTX_NEW, 1, [])
++        AC_DEFINE(HAVE_EVP_CIPHERINIT_EX, 1, [])
++        AC_DEFINE(HAVE_LIBCRYPTO, 1, [])
++        AC_DEFINE(HAVE_OPENSSL_EVP_H, 1, [])
++    else
++        AC_MSG_ERROR([Unable to find wolfssl.])
++    fi
++fi
++
+ # Check for OpenSSL/libressl libcrypto
+ AC_MSG_CHECKING(whether to use OpenSSL/libressl libcrypto)
+ # Specify location for both includes and libraries.
+@@ -872,7 +899,11 @@ AC_ARG_WITH(crypto,
+     AS_HELP_STRING([--with-crypto]@<:@=DIR@:>@,
+ 		   [use OpenSSL/libressl libcrypto (located in directory DIR, if specified) @<:@default=yes, if available@:>@]),
+ [
+-	if test $withval = no
++	if test $USE_WOLFSSL = yes
++	then
++		want_libcrypto=no
++		AC_MSG_RESULT(no)
++	elif test $withval = no
+ 	then
+ 		# User doesn't want to link with libcrypto.
+ 		want_libcrypto=no
+@@ -898,12 +929,18 @@ AC_ARG_WITH(crypto,
+ 		LIBS="-L$withval/lib $LIBS"
+ 	fi
+ ],[
++	if test $USE_WOLFSSL = yes
++	then
++		want_libcrypto=no
++		AC_MSG_RESULT(no)
+ 	#
+ 	# Use libcrypto if it's present, otherwise don't; no directory
+ 	# was specified.
+ 	#
+-	want_libcrypto=ifavailable
+-	AC_MSG_RESULT([yes, if available])
++	else
++		want_libcrypto=ifavailable
++		AC_MSG_RESULT([yes, if available])
++	fi
+ ])
+ if test "$want_libcrypto" != "no"; then
+ 	#
+diff --git a/print-esp.c b/print-esp.c
+index 6fabff1..71166bf 100644
+--- a/print-esp.c
++++ b/print-esp.c
+@@ -37,6 +37,10 @@
+  * is the simplest way of handling the dependency.
+  */
+ #ifdef HAVE_LIBCRYPTO
++#ifdef HAVE_WOLFSSL
++#include <wolfssl/options.h>
++#include <openssl/ssl.h>
++#endif
+ #ifdef HAVE_OPENSSL_EVP_H
+ #include <openssl/evp.h>
+ #else
+@@ -259,7 +263,13 @@ int esp_print_decrypt_buffer_by_ikev2(netdissect_options *ndo,
+ 		EVP_CIPHER_CTX_free(ctx);
+ 		(*ndo->ndo_error)(ndo, "can't allocate memory for decryption buffer");
+ 	}
++#ifdef HAVE_WOLFSSL
++	/* wolfSSL expects the length passed in to include the padding, so we use
++	 * buffer_size here instead of len. */
++	EVP_Cipher(ctx, output_buffer, input_buffer, buffer_size);
++#else
+ 	EVP_Cipher(ctx, output_buffer, input_buffer, len);
++#endif
+ 	EVP_CIPHER_CTX_free(ctx);
+ 
+ 	/*
+@@ -617,7 +627,11 @@ static void esp_init(netdissect_options *ndo _U_)
+ #if !defined(OPENSSL_API_COMPAT) || OPENSSL_API_COMPAT < 0x10100000L
+ 	OpenSSL_add_all_algorithms();
+ #endif
++/* wolfSSL doesn't support EVP_add_cipher_alias, and "3des" is already mapped
++ * correctly in wolfSSL_EVP_get_cipherbyname. */
++#ifndef HAVE_WOLFSSL
+ 	EVP_add_cipher_alias(SN_des_ede3_cbc, "3des");
++#endif
+ }
+ USES_APPLE_RST
+ 
+diff --git a/print-tcp.c b/print-tcp.c
+index b80a2f2..9d75026 100644
+--- a/print-tcp.c
++++ b/print-tcp.c
+@@ -52,6 +52,9 @@ __RCSID("$NetBSD: print-tcp.c,v 1.8 2007/07/24 11:53:48 drochner Exp $");
+ #include "rpc_msg.h"
+ 
+ #ifdef HAVE_LIBCRYPTO
++#ifdef HAVE_WOLFSSL
++#include <wolfssl/options.h>
++#endif
+ #include <openssl/md5.h>
+ #include "signature.h"
+ 
+diff --git a/signature.c b/signature.c
+index 204e345..0da2e3a 100644
+--- a/signature.c
++++ b/signature.c
+@@ -28,6 +28,9 @@
+ #include "signature.h"
+ 
+ #ifdef HAVE_LIBCRYPTO
++#ifdef HAVE_WOLFSSL
++#include <wolfssl/options.h>
++#endif
+ #include <openssl/md5.h>
+ #endif
+ 
+diff --git a/tcpdump.c b/tcpdump.c
+index 043bda1..c620f14 100644
+--- a/tcpdump.c
++++ b/tcpdump.c
+@@ -63,6 +63,10 @@ The Regents of the University of California.  All rights reserved.\n";
+ #endif
+ 
+ #ifdef HAVE_LIBCRYPTO
++#ifdef HAVE_WOLFSSL
++#include <wolfssl/options.h>
++#include <openssl/ssl.h>
++#endif
+ #include <openssl/crypto.h>
+ #endif
+ 
+@@ -1146,6 +1150,10 @@ main(int argc, char **argv)
+ 	ndo_set_function_pointers(ndo);
+ 	ndo->ndo_snaplen = DEFAULT_SNAPLEN;
+ 
++#if defined(HAVE_WOLFSSL) && defined(DEBUG_WOLFSSL)
++	wolfSSL_Debugging_ON();
++#endif
++
+ 	cnt = -1;
+ 	device = NULL;
+ 	infile = NULL;

--- a/recipes-support/tcpdump/tcpdump_4.9.3.bbappend
+++ b/recipes-support/tcpdump/tcpdump_4.9.3.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://tcpdump-4.9.3.patch"
+PACKAGECONFIG_remove = "openssl"
+DEPENDS += "wolfssl"
+EXTRA_OECONF += "--with-wolfssl=${STAGING_EXECPREFIXDIR}"

--- a/recipes-support/tcpdump/wolfssl_%.bbappend
+++ b/recipes-support/tcpdump/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--enable-tcpdump"


### PR DESCRIPTION
- bind
- socat
- rsyslog
- net-snmp
- libssh2
- strongswan (supports wolfSSL upstream)
- tcpdump

These BitBake files come from some customer work we did making their Yocto image FIPS-compliant.

Additionally, I've adjusted the OpenSSH 8.5p1 patch to reflect the latest in our OSP repo.