### PR TITLE
layer.conf: fix IMAGE_INSTALL append

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,7 +18,7 @@ BBFILE_COLLECTIONS += "wolfssl"
 BBFILE_PATTERN_wolfssl := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wolfssl = "5"
 
-IMAGE_INSTALL:append = "wolfssl"
+IMAGE_INSTALL:append = " wolfssl"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
 LAYERSERIES_COMPAT_wolfssl = "kirkstone"


### PR DESCRIPTION
The 'append' operator requires a leading space to prevent conflicts.

This is a regression introduced in commit: 562f628a22d5a1709c24751c54f0b1c70cec608d