### PR TITLE
Kirkstone Branch: Fixed compile issue with wolftpm v2.7.0 and wolfssl v5.6.3 by includi…

### DIFF
--- a/recipes-wolfssl/wolftpm/files/v2.7.0+pr277.diff
+++ b/recipes-wolfssl/wolftpm/files/v2.7.0+pr277.diff
@@ -1,0 +1,19 @@
+diff --git a/wolftpm/tpm2_types.h b/wolftpm/tpm2_types.h
+index 6edbdee..745b17c 100644
+--- a/wolftpm/tpm2_types.h
++++ b/wolftpm/tpm2_types.h
+@@ -197,6 +197,14 @@ typedef int64_t  INT64;
+     #define XATOI(s)          atoi((s))
+ #endif
+ 
++/* make sure file IO macros are available for examples */
++#ifndef XFEOF /* used in pcr/extend example */
++    #define XFEOF      feof
++#endif
++#ifndef XREWIND /* used in tpm_test_keys.c */
++    #define XREWIND    rewind
++#endif
++
+ /* enable way for customer to override printf */
+ #ifdef XPRINTF
+     #undef  printf

--- a/recipes-wolfssl/wolftpm/wolftpm_2.7.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_2.7.0.bb
@@ -13,6 +13,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 DEPENDS += "wolfssl"
 
 SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=a0bd9fef9842ffbdf933afbd15ed4fa8bc8daf26"
+SRC_URI += "file://v2.7.0+pr277.diff"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
…ng a patch for wolftpm 2.7.0 based on pr 277 in wolftpm repo.