### PR TITLE
Master: Updating BBappends to solve uneeded enables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ After installing your build's Yocto/OpenEmbedded components:
    ```
 
 2. Once the 'meta-wolfssl' layer has been added to your BBLAYERS collection,
+   you then will need to go to the local.conf file located in 
+   meta-wolfssl/conf/. The products that you want to compile will need to be
+   uncommented.
+
+   As an example if wolfssh is desired the following needs to occur:
+   From "meta-wolfssl" directory
+   ```
+   $ vim conf/layer.conf
+   ```
+   Then look for the text:
+   ```
+   # Uncomment if building wolfssh with wolfssl
+   #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
+   #            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
+   ```
+   Then uncomment by removing the #, it should look like this afterwards
+   ```
+   # Uncomment if building wolfssh with wolfssl
+   BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
+               ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
+   ```
+
+   This needs to be done in order to preform a bitbake operation on any of the 
+   products or tests. You should uncomment products you want to use and 
+   comment out products you don't want to use to avoid uneeded --enable-options
+   in your wolfssl version. wolfssl and wolfclu uncommented by default.
+
+3. Once the products that need to be compiled are uncommented,
    you can build the individual product recipes to make sure they compile
    successfully:
 
@@ -59,13 +87,12 @@ After installing your build's Yocto/OpenEmbedded components:
    $ bitbake wolftpm
    $ bitbake wolfclu
    ```
-
-2. Edit your build's local.conf file to install the libraries you would like
+4. Edit your build's local.conf file to install the libraries you would like
    included (ie: wolfssl, wolfssh, wolfmqtt, wolftpm) by adding a
-   IMAGE_INSTALL_append line:
+   IMAGE_INSTALL:append line:
 
     ```
-    IMAGE_INSTALL_append = "wolfssl wolfssh wolfmqtt wolftpm wolfclu"
+    IMAGE_INSTALL:append = " wolfssl wolfssh wolfmqtt wolftpm wolfclu "
     ```
 
 Once your image has been built, the default location for the wolfSSL library

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,12 +1,31 @@
 # We have a conf and classes directory, add to BBPATH
 BBPATH := "${LAYERDIR}:${BBPATH}"
 
-# We have a packages directory, add to BBFILES
-BBFILES += "${LAYERDIR}/recipes-wolfssl/*/*.bb \
-            ${LAYERDIR}/recipes-wolfssl/*/*.bbappend"
 
-BBFILES += "${LAYERDIR}/recipes-examples/*/*/*.bb \
-            ${LAYERDIR}/recipes-examples/*/*/*.bbappend"
+# We have a packages directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssl/*.bb \
+            ${LAYERDIR}/recipes-wolfssl/wolfssl/*.bbappend"
+
+#Comment out if you don't want to use wolfclu 
+BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfclu/*.bb \
+            ${LAYERDIR}/recipes-wolfssl/wolfclu/*.bbappend"                                                 
+
+# Uncomment if wanting to use example tests                                                 
+#BBFILES += "${LAYERDIR}/recipes-examples/*/*/*.bb \
+#            ${LAYERDIR}/recipes-examples/*/*/*.bbappend"
+
+# Uncomment if building wolfssh with wolfssl
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
+
+# Uncomment if building wolfmqtt with wolfssl
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bbappend"
+
+# Uncomment if building wolftpm with wolfssl
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolftpm/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend"
+
 
 # Uncomment if building bind with wolfSSL.
 #BBFILES += "${LAYERDIR}/recipes-connectivity/bind/*.bbappend"


### PR DESCRIPTION
I found a bug? What would happen is that the bbappend in the local.conf would read all the appends for wolfssl and add them during wolfssl's configuration. So it would add enable options whether or not you had the accompanying product.

For example if you only wanted wolfssl, --enable-ssh would be added to the configure due to the append file located in wolfssh recipe directory. This caused some builds to break.
