### PR TITLE
Update layer.conf override syntax

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -59,7 +59,7 @@ BBFILE_PATTERN_wolfssl := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wolfssl = "5"
 
 # Yocto manual recommends a space before this list to prevent conflicts
-IMAGE_INSTALL_append = " wolfssl"
+IMAGE_INSTALL:append = " wolfssl"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
 LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus dunfell hardknott \


### PR DESCRIPTION
_append has been changed to :append since honister release.

This has been breaking layerindex updates:
https://layers.openembedded.org/layerindex/updates/37926/
`ERROR: Variable IMAGE_INSTALL_append file: /opt/workdir/https___github_com_wolfSSL_meta-wolfssl/conf/layer.conf line: 62 contains an operation using the old override syntax. Please convert this layer/metadata before attempting to use with a newer bitbake.`


Signed-off-by: Tim Orling <tim.orling@konsulko.com>