### PR TITLE
Kirkstone bugreport pr72 appendfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,63 +37,78 @@ git clone https://github.com/wolfSSL/meta-wolfssl.git
 
 After installing your build's Yocto/OpenEmbedded components:
 
-1. Insert the 'meta-wolfssl' layer location into your build's bblayers.conf
-   file, in the BBLAYERS section:
+1.  Insert the 'meta-wolfssl' layer location into your build's bblayers.conf
+    file, in the BBLAYERS section:
 
-   ```
-   BBLAYERS ?= " \
+    ```
+    BBLAYERS ?= " \
        ...
        /path/to/yocto/poky/meta-wolfssl \
        ...
-   "
-   ```
+    "
+    ```
 
-2. Once the 'meta-wolfssl' layer has been added to your BBLAYERS collection,
-   you then will need to go to the local.conf file located in 
-   meta-wolfssl/conf/. The products that you want to compile will need to be
-   uncommented.
+2.  Once the 'meta-wolfssl' layer has been added to your BBLAYERS collection,
+    you have two options
+   
+    1.  If you want to directly add wolfssl recipes to your image recipe 
+        proceed to step 3.
 
-   As an example if wolfssh is desired the following needs to occur:
-   From "meta-wolfssl" directory
-   ```
-   $ vim conf/layer.conf
-   ```
-   Then look for the text:
-   ```
-   # Uncomment if building wolfssh with wolfssl
-   #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
-   #            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
-   ```
-   Then uncomment by removing the #, it should look like this afterwards
-   ```
-   # Uncomment if building wolfssh with wolfssl
-   BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
+
+    2.  If you want to run `bitbake wolf*` on a particular recipe then it needs 
+        uncommented in `local.conf` located in `meta-wolfssl/conf/`. 
+
+        As an example if wolfssh is desired the following needs to occur:
+        From "meta-wolfssl" directory
+        ```
+        $ vim conf/layer.conf
+        ```
+        Then look for the text:
+        ```
+        # Uncomment if building wolfssh with wolfssl
+        #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
+        #            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
+        ```
+        Then uncomment by removing the #, it should look like this afterwards
+        ```
+        # Uncomment if building wolfssh with wolfssl
+        BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
                ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
-   ```
+        ```
 
-   This needs to be done in order to preform a bitbake operation on any of the 
-   products or tests. You should uncomment products you want to use and 
-   comment out products you don't want to use to avoid uneeded --enable-options
-   in your wolfssl version. wolfssl and wolfclu uncommented by default.
+        This needs to be done in order to preform a bitbake operation on any of the 
+        recipes. 
+        
+        You should make sure to comment out recipes you don't want to use to 
+        avoid uneeded --enable-options in your wolfssl version. wolfssl is 
+        uncommented by default.
 
-3. Once the products that need to be compiled are uncommented,
-   you can build the individual product recipes to make sure they compile
-   successfully:
+        Once the recipes that need to be compiled are uncommented,
+        you can build the individual product/test recipes to make sure they 
+        compile successfully:
 
-   ```
-   $ bitbake wolfssl
-   $ bitbake wolfssh
-   $ bitbake wolfmqtt
-   $ bitbake wolftpm
-   $ bitbake wolfclu
-   ```
-4. Edit your build's local.conf file to install the libraries you would like
-   included (ie: wolfssl, wolfssh, wolfmqtt, wolftpm) by adding a
-   IMAGE_INSTALL:append line:
+        ```
+        $ bitbake wolfssl
+        $ bitbake wolfssh
+        $ bitbake wolfmqtt
+        $ bitbake wolftpm
+        $ bitbake wolfclu
+        ```
+
+3.  Edit your build's local.conf file to install the recipes you would like
+    included (ie: wolfssl, wolfssh, wolfmqtt, wolftpm) by adding a
+    IMAGE_INSTALL:append line:
 
     ```
     IMAGE_INSTALL:append = " wolfssl wolfssh wolfmqtt wolftpm wolfclu "
     ```
+    This will add the necassary --enable-* options necassary to use your
+    specific combination of recipes.
+
+    If you did step 2.2 make sure you comment out recipes that you don't desire
+    because leaving them uncommented may add unneed --enable-* options in your 
+    build, which could increase the size of the build and turn on uneeded 
+    features.
 
 Once your image has been built, the default location for the wolfSSL library
 on your machine will be in the "/usr/lib" directory.

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,28 +5,92 @@ BBPATH := "${LAYERDIR}:${BBPATH}"
 BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssl/*.bb \
             ${LAYERDIR}/recipes-wolfssl/wolfssl/*.bbappend"
 
-#Comment out if you don't want to use wolfclu 
-BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfclu/*.bb \
-            ${LAYERDIR}/recipes-wolfssl/wolfclu/*.bbappend"                                                 
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfssl', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssl/*.bb ${LAYERDIR}/recipes-wolfssl/wolfssl/*.bbappend', \
+                                 '', d)}"
 
-# Uncomment if wanting to use example tests                                                 
-#BBFILES += "${LAYERDIR}/recipes-examples/*/*/*.bb \
-#            ${LAYERDIR}/recipes-examples/*/*/*.bbappend"
+#Comment out if you don't want to use wolfclu 
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfclu/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfclu/*.bbappend"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfclu', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfclu/*.bb ${LAYERDIR}/recipes-wolfssl/wolfclu/*.bbappend', \
+                                 '', d)}"
+
+# Uncomment if wanting to use example test/benchmark for wolfcrypt                                                
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb \
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb \
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfcryptbenchmark', \
+                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb', \
+                                 '', d)}"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfcrypttest', \
+                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb', \
+                                 '', d)}"
+
 
 # Uncomment if building wolfssh with wolfssl
 #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
 #            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfssh', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend', \
+                                 '', d)}"
+
 
 # Uncomment if building wolfmqtt with wolfssl
 #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bb \
 #            ${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bbappend"
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfmqtt', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bb ${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bbappend', \
+                                 '', d)}"
+
 
 # Uncomment if building wolftpm with wolfssl
 #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolftpm/*.bb \
 #            ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend"
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolftpm', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolftpm/*.bb ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend', \
+                                 '', d)}"
+
+# Uncomment if building wolfssl-py
+# BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bbappend"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfssl-py', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bb ${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bbappend', \
+                                 '', d)}"
+
+# Uncomment if building wolfcrypt-py
+# BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bbappend"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfcrypt-py', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bb ${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bbappend', \
+                                 '', d)}"
+
+
+# Uncomment if wanting to use example tests for wolfssl-py/wolfcrypt-py                                                 
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb \
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolf-py-tests', \
+                                 '${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb', \
+                                 '', d)}"
+
 
 # Uncomment if building curl with wolfSSL.
 #BBFILES += "${LAYERDIR}/recipes-support/curl/*.bbappend"
+
 
 # Uncomment if building OpenSSH with wolfSSL.
 #BBFILES += "${LAYERDIR}/recipes-connectivity/openssh/*.bbappend"


### PR DESCRIPTION
This pull request is in response to #72 

This adds the ability to directly add a recipe to IMAGE_INSTALL without having to uncomment the recipes in `conf/layer.conf`

NOTE: If you wanted to bitbake a particular recipe you still need to uncomment the recipe in `conf/layer.conf`. 

The README has been updated to reflect these changes
