### PR TITLE
layerconf: add nanbield to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -40,4 +40,4 @@ BBFILE_PRIORITY_wolfssl = "5"
 IMAGE_INSTALL:append = " wolfssl"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
-LAYERSERIES_COMPAT_wolfssl = "kirkstone"
+LAYERSERIES_COMPAT_wolfssl = "kirkstone nanbield"


### PR DESCRIPTION
At this moment:
-master supports up to Dunfell
-kirkstone supports only Kirkstone

From what I understand WolfSSL does not create a new branch for Nanbield (and later Scarthgap) and we should use the Kirkstone branch which should be compatible with Nanbield.

We added Nanbield tio the Kirkstone layer and tested this and it works fine. This PR adds Nanbield to the compatible list of the Kirkstone layer.

During build we get a QA warning, but everything work as it should:
WARNING: wolfssl-5.6.6-r0 do_package_qa: QA Issue: File /usr/lib/libwolfssl.so.42.0.0 in package wolfssl contains reference to TMPDIR [buildpaths]