### PR TITLE
Feature Request: PR76 - Adding yocto nanbield support on kirkstone branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,12 +262,12 @@ looks as follows:
 
 - If wolfSSL-py and wolfCrypt-py are both desired on target system
 ```
-Image_INSTALL:append = " wolfssl wolfssl-py wolfcrypt-py wolf-py-tests python3 python3-cffi python3-pytest"
+IMAGE_INSTALL:append = " wolfssl wolfssl-py wolfcrypt-py wolf-py-tests python3 python3-cffi python3-pytest"
 ```
 
 This places the tests in the root home directory
 ```
-$ cd /home/root
+$ cd /home/root/wolf-py-tests/
 $ ls
     wolfcrypt-py-test wolfssl-py-test
 ```
@@ -276,12 +276,12 @@ navigate into the desired test:
 
 for wolfssl-py
 ```
-$ cd /home/root/wolfssl-py-test
+$ cd /home/root/wolf-py-tests/wolfssl-py-test
 
 ```
 for wolfcrypt-py
 ```
-$ cd /home/root/wolfcrypt-py-test
+$ cd /home/root/wolf-py-tests/wolfcrypt-py-test
 ```
 
 once in the desired test directory, begin the test by calling pytest

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -20,17 +20,19 @@ BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
                                  '', d)}"
 
 # Uncomment if wanting to use example test/benchmark for wolfcrypt                                                
-# BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb 
-# BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb 
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb \
+#             ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bbappend" 
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb \
+#             ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bbappend" 
 
 BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
                                  'wolfcryptbenchmark', \
-                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb', \
+                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bbappend', \
                                  '', d)}"
 
 BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
                                  'wolfcrypttest', \
-                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb', \
+                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bbappend' , \
                                  '', d)}"
 
 
@@ -54,14 +56,14 @@ BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
 
 # Uncomment if building wolftpm with wolfssl
 #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolftpm/*.bb \
-#            ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend"
+#           ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend"
 BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
                                  'wolftpm', \
                                  '${LAYERDIR}/recipes-wolfssl/wolftpm/*.bb ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend', \
                                  '', d)}"
 
 # Uncomment if building wolfssl-py
-# BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bb \
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bb \
 #            ${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bbappend"
 
 BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
@@ -70,7 +72,7 @@ BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
                                  '', d)}"
 
 # Uncomment if building wolfcrypt-py
-# BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bb \
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bb \
 #            ${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bbappend"
 
 BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
@@ -80,11 +82,12 @@ BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
 
 
 # Uncomment if wanting to use example tests for wolfssl-py/wolfcrypt-py                                                 
-#BBFILES += "${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb 
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb \
+#            ${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bbappend" 
 
 BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
                                  'wolf-py-tests', \
-                                 '${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb', \
+                                 '${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb ${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bbappend', \
                                  '', d)}"
 
 
@@ -104,4 +107,4 @@ BBFILE_PRIORITY_wolfssl = "5"
 IMAGE_INSTALL:append = " wolfssl"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
-LAYERSERIES_COMPAT_wolfssl = "kirkstone"
+LAYERSERIES_COMPAT_wolfssl = "kirkstone nanbield"

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
@@ -16,11 +16,11 @@ SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=66
 
 S = "${WORKDIR}/git/wolfcrypt/benchmark"
 
-do_compile() {
-    ${CC} ${CFLAGS} -DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DUSE_FLAT_BENCHMARK_H -DBENCH_EMBEDDED -Wall -include wolfssl/options.h -o wolfcryptbenchmark ${S}/benchmark.c -lwolfssl ${LDFLAGS}
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install() {
+    install -d ${D}${datadir}/wolfcrypt-benchmark
+    echo "This is a dummy package" > ${D}${datadir}/wolfcrypt-benchmark/README.txt
 }
 
-do_install() {
-    install -d ${D}${bindir}
-    install -m 0755 ${S}/wolfcryptbenchmark ${D}${bindir}
-}
+FILES:${PN} += "${datadir}/wolfcrypt-benchmark/*"

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfssl_%.bbappend
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfssl_%.bbappend
@@ -1,0 +1,11 @@
+WOLFCRYPT_BENCHMARK_DIR = "${B}/wolfcrypt/benchmark/.libs"                      
+WOLFCRYPT_BENCHMARK = "benchmark"                                               
+WOLFCRYPT_BENCHMARK_YOCTO = "wolfcryptbenchmark" 
+
+do_install:append() {
+    bbnote "Installing wolfCrypt Benchmarks"                                
+    install -m 0755 -d ${D}${bindir}                                        
+    cp ${WOLFCRYPT_BENCHMARK_DIR}/${WOLFCRYPT_BENCHMARK} ${D}${bindir}/${WOLFCRYPT_BENCHMARK_YOCTO}
+}
+
+TARGET_CFLAGS += "-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DBENCH_EMBEDDED"

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
@@ -16,11 +16,12 @@ SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=66
 
 S = "${WORKDIR}/git/wolfcrypt/test"
 
-do_compile() {
-    ${CC} ${CFLAGS} -DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DUSE_FLAT_TEST_H -Wall -include wolfssl/options.h -o wolfcrypttest ${S}/test.c -lwolfssl ${LDFLAGS}
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install() {
+    install -d ${D}${datadir}/wolfcrypt-test
+    echo "This is a dummy package" > ${D}${datadir}/wolfcrypt-test/README.txt
 }
 
-do_install() {
-    install -d ${D}${bindir}
-    install -m 0755 ${S}/wolfcrypttest ${D}${bindir}
-}
+FILES:${PN} += "${datadir}/wolfcrypt-test/*"

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfssl_%.bbappend
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfssl_%.bbappend
@@ -1,0 +1,11 @@
+WOLFCRYPT_TEST_DIR = "${B}/wolfcrypt/test/.libs"
+WOLFCRYPT_TEST = "testwolfcrypt"
+WOLFCRYPT_TEST_YOCTO = "wolfcrypttest"
+
+do_install:append() {                                                           
+    bbnote "Installing wolfCrypt Tests"                                     
+    install -m 0755 -d ${D}${bindir}                                        
+    cp -r ${WOLFCRYPT_TEST_DIR}/${WOLFCRYPT_TEST} ${D}${bindir}/${WOLFCRYPT_TEST_YOCTO}
+} 
+
+TARGET_CFLAGS += "-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_RSA_KEY_CHECK -DNO_WRITE_TEMP_FILES"

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
@@ -23,31 +23,15 @@ DEPENDS += " wolfssl-py \
 
 S = "${WORKDIR}/git"
 
+WOLF_PY_TEST_TARGET_DIR = "/home/root/wolf-py-tests"
+WOLF_PY_TEST_README = "README.txt"
 
-WOLFSSL_PY_TEST_DIR = "${TMPDIR}/work/${PACKAGE_ARCH}-${DISTRO}-${BUILD_OS}/wolfssl-py/${PV}-${PR}/git/*"
-WOLFSSL_PY_TEST_TARGET_DIR = "${D}/home/root/wolfssl-py-test"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
 
-WOLFCRYPT_PY_TEST_DIR = "${TMPDIR}/work/${PACKAGE_ARCH}-${DISTRO}-${BUILD_OS}/wolfcrypt-py/${PV}-${PR}/git/*"
-WOLFCRYPT_PY_TEST_TARGET_DIR = "${D}/home/root/wolfcrypt-py-test"
-
-do_configure(){
+do_install() {
+    install -d ${D}${WOLF_PY_TEST_TARGET_DIR}
+    echo "This is a dummy package" > ${D}${WOLF_PY_TEST_TARGET_DIR}/${WOLF_PY_TEST_README}
 }
 
-do_compile(){
-}
-
-do_install:prepend(){
-  
-    install -m 0755 -d ${WOLFCRYPT_PY_TEST_TARGET_DIR}
-    install -m 0755 -d ${WOLFSSL_PY_TEST_TARGET_DIR}
-    cp -r ${WOLFSSL_PY_TEST_DIR} ${WOLFSSL_PY_TEST_TARGET_DIR}
-    cp -r ${WOLFCRYPT_PY_TEST_DIR} ${WOLFCRYPT_PY_TEST_TARGET_DIR}
-}
-
-FILES:${PN} += "  \ 
-                  /home/root/wolfcrypt-py-test/* \
-                  /home/root/wolfssl-py-test/* \
-               "
-
-
-
+FILES:${PN} += "${WOLF_PY_TEST_TARGET_DIR}/${WOLF_PY_TEST_README}"

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolfcrypt-py_%.bbappend
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolfcrypt-py_%.bbappend
@@ -1,0 +1,13 @@
+WOLFCRYPT_PY_TEST_DIR = "${S}/*"                                                
+WOLFCRYPT_PY_TEST_TARGET_DIR = "${D}/home/root/wolf-py-tests/wolfcrypt-py-test"
+
+do_install:append() {
+    bbnote "Installing wolfCrypt-py tests"                                     
+    install -m 0755 -d ${WOLFCRYPT_PY_TEST_TARGET_DIR}                      
+    cp -r ${WOLFCRYPT_PY_TEST_DIR}/* ${WOLFCRYPT_PY_TEST_TARGET_DIR}        
+}
+
+# Python Specific option
+export PYTHONDONTWRITEBYTECODE = "1" 
+
+FILES:${PN} += "  /home/root/wolf-py-tests/wolfcrypt-py-test/*"

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl-py_%.bbappend
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl-py_%.bbappend
@@ -1,0 +1,13 @@
+WOLFSSL_PY_TEST_DIR = "${S}/*"                                                  
+WOLFSSL_PY_TEST_TARGET_DIR = "${D}/home/root/wolf-py-tests/wolfssl-py-test"
+
+do_install:append() {                                                            
+    bbnote "Installing wolfssl-py Tests"                                    
+    install -m 0755 -d ${WOLFSSL_PY_TEST_TARGET_DIR}                        
+    cp -r ${WOLFSSL_PY_TEST_DIR}/* ${WOLFSSL_PY_TEST_TARGET_DIR}            
+}       
+
+# Python Specific option                                                        
+export PYTHONDONTWRITEBYTECODE = "1" 
+
+FILES:${PN} += " /home/root/wolf-py-tests/wolfssl-py-test/* "

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl_%.bbappend
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl_%.bbappend
@@ -1,0 +1,12 @@
+WOLFSSL_PY_TEST_CERTS_DIR = "/home/root/wolf-py-tests/wolfssl-py-test/certs"
+WOLFSSL_PY_CERTS_DIR = "/certs"
+
+do_install:append() {
+    bbnote "Installing Certs Directory for wolf-py Tests"                   
+    install -m 0755 -d ${D}${WOLFSSL_PY_TEST_CERTS_DIR}                     
+    cp -r ${S}${WOLFSSL_PY_CERTS_DIR}/*.der ${D}${WOLFSSL_PY_TEST_CERTS_DIR}
+    cp -r ${S}${WOLFSSL_PY_CERTS_DIR}/*.pem ${D}${WOLFSSL_PY_TEST_CERTS_DIR}
+}
+
+
+FILES:${PN} += " ${WOLFSSL_PY_TEST_CERTS_DIR}/* "

--- a/recipes-wolfssl/wolfclu/wolfclu_0.1.5.bb
+++ b/recipes-wolfssl/wolfclu/wolfclu_0.1.5.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "wolfCLU is a lightweight command line utility written in C and \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfclu"
 BUGTRACKER = "https://github.com/wolfssl/wolfclu/issues"
 SECTION = "bin"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 PROVIDES += "wolfclu"
@@ -27,4 +27,13 @@ BBCLASSEXTEND += "native nativesdk"
 do_configure:prepend() {
     (cd ${S}; ./autogen.sh; cd -)
 }
+
+# Add reproducible build flags
+CFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+CXXFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+LDFLAGS:append = " -Wl,--build-id=none"
+
+# Ensure consistent locale
+export LC_ALL = "C"
+
 

--- a/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.6.0.bb
+++ b/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.6.0.bb
@@ -13,31 +13,31 @@ SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
-
-
-
 SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=1c242652a799190b55cc20964135297357e00b67"
 
 
 DEPENDS += " wolfssl \
             python3-pip-native \
             python3-cffi-native \
+            python3-cffi \
             python3-native \
+            python3 \
             "
 
 inherit setuptools3  
 
 S = "${WORKDIR}/git"
 
-
 WOLFSSL_YOCTO_DIR = "${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
-
 
 do_compile:prepend(){
     export USE_LOCAL_WOLFSSL=${WOLFSSL_YOCTO_DIR}
-    
-
 }
 
+# Add reproducible build flags
+CFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+CXXFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+LDFLAGS += " -Wl,--build-id=none"
 
-
+# Ensure consistent locale for build reproducibility
+export LC_ALL = "C"

--- a/recipes-wolfssl/wolfmqtt/wolfmqtt_1.18.0.bb
+++ b/recipes-wolfssl/wolfmqtt/wolfmqtt_1.18.0.bb
@@ -24,3 +24,11 @@ EXTRA_OECONF = "--with-libwolfssl-prefix=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfs
 do_configure:prepend() {
     (cd ${S}; ./autogen.sh; cd -)
 }
+
+# Add reproducible build flags                                                  
+CFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."                       
+CXXFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."                     
+LDFLAGS:append = " -Wl,--build-id=none"                                         
+
+# Ensure consistent locale                                                      
+export LC_ALL = "C" 

--- a/recipes-wolfssl/wolfssh/wolfssh_1.4.15.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.4.15.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "wolfSSH is a lightweight SSHv2 library written in ANSI C and \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssh"
 BUGTRACKER = "https://github.com/wolfssl/wolfssh/issues"
 SECTION = "libs"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSING;md5=2c2d0ee3db6ceba278dd43212ed03733"
 
 DEPENDS += "wolfssl"
@@ -22,3 +22,11 @@ EXTRA_OECONF = "--with-wolfssl=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
 do_configure:prepend() {
     (cd ${S}; ./autogen.sh; cd -)
 }
+
+# Add reproducible build flags                                                  
+CFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."                       
+CXXFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."                     
+LDFLAGS:append = " -Wl,--build-id=none"                                         
+
+# Ensure consistent locale                                                      
+export LC_ALL = "C" 

--- a/recipes-wolfssl/wolfssl-py/wolfssl-py_5.6.0.bb
+++ b/recipes-wolfssl/wolfssl-py/wolfssl-py_5.6.0.bb
@@ -11,9 +11,6 @@ SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
-
-
-
 SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=0a8a76c6d426289d9019e10d02db9a5af051fba8"
 
 
@@ -33,15 +30,16 @@ inherit python_setuptools_build_meta
 
 S = "${WORKDIR}/git"
 
-
 WOLFSSL_YOCTO_DIR = "${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
 
-
 do_compile:prepend(){
-  
     export USE_LOCAL_WOLFSSL=${WOLFSSL_YOCTO_DIR}
-
 }
 
+# Add reproducible build flags
+CFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+CXXFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+LDFLAGS += " -Wl,--build-id=none"
 
-
+# Ensure consistent locale for build reproducibility
+export LC_ALL = "C"

--- a/recipes-wolfssl/wolfssl/wolfssl_5.6.6.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.6.6.bb
@@ -1,17 +1,12 @@
 SUMMARY = "wolfSSL Lightweight Embedded SSL/TLS Library"
-DESCRIPTION = "wolfSSL is a lightweight SSL/TLS library written in C and \
-               optimized for embedded and RTOS environments. It can be up \
-               to 20 times smaller than OpenSSL while still supporting \
-               a full TLS client and server, up to TLS 1.3"
-HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
+DESCRIPTION = "wolfSSL is a lightweight SSL/TLS library written in C and optimized for embedded and RTOS environments. It supports a full TLS client and server, up to TLS 1.3."
+HOMEPAGE = "https://www.wolfssl.com/products/wolfssl/"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 DEPENDS += "util-linux-native"
 
-PROVIDES += "cyassl"
-RPROVIDES_${PN} = "cyassl"
 PROVIDES += "wolfssl"
 RPROVIDES_${PN} = "wolfssl"
 
@@ -19,10 +14,12 @@ SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=66
 
 S = "${WORKDIR}/git"
 
+
 inherit autotools pkgconfig
 
 do_configure:prepend() {
-    (cd ${S}; ./autogen.sh; cd -)
+    (cd ${S}; ./autogen.sh; cd -)    
 }
 
-BBCLASSEXTEND += "native nativesdk"
+BBCLASSEXTEND = "native nativesdk"
+EXTRA_OECONF += "--enable-reproducible-build"

--- a/recipes-wolfssl/wolftpm/wolftpm_3.1.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_3.1.0.bb
@@ -23,3 +23,10 @@ EXTRA_OECONF = "--with-wolfcrypt=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
 do_configure:prepend() {
     (cd ${S}; ./autogen.sh; cd -)
 }
+# Add reproducible build flags                                                  
+CFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."                       
+CXXFLAGS:append = " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."                     
+LDFLAGS:append = " -Wl,--build-id=none"                                         
+
+# Ensure consistent locale                                                      
+export LC_ALL = "C" 


### PR DESCRIPTION
This is a PR in response to the feature request from PR: #76 

This pr adds the functionality to use yocto nanbield.

This includes addressing TMPDR warnings that appear when compiling/install libwolf* packages via bitbake when on yocto nanbield. 

This pr also includes an update to how the examples for wolfssl-py and wolfssl get moved over to the image.