### PR TITLE
Adding ability to use 2.x, 3.x, and newer versions of Yocto with 1 set of recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ This layer currently provides recipes for the following wolfSSL products:
 - [wolfSSH lightweight SSH library](https://www.wolfssl.com/products/wolfssh/)
 - [wolfMQTT lightweight MQTT client library](https://www.wolfssl.com/products/wolfmqtt/)
 - [wolfTPM portable TPM 2.0 library](https://www.wolfssl.com/products/wolftpm/)
+- [wolfSSL-py A Python wrapper for the wolfSSL library](https://github.com/wolfSSL/wolfssl-py)
+- [wolfCrypt-py A Python Wrapper for the wolfCrypt API](https://github.com/wolfSSL/wolfcrypt-py)
+
+These recipes have been tested using these versions of yocto:
+
+- Nanbield      (v4.3)
+- Kirkstone     (v4.0)
+- Hardknott     (v3.3)
+- Gatesgarth    (v3.2)
+- Dunfell       (v3.1)
+- Zeus          (v3.0)
+- Thud          (v2.6)
+- Sumo          (v2.5)    
 
 The wolfSSL library recipe is also included in the openembedded meta-networking
 layer, located [here](https://github.com/openembedded/meta-openembedded/tree/master/meta-networking/recipes-connectivity/wolfssl).
@@ -37,79 +50,110 @@ git clone https://github.com/wolfSSL/meta-wolfssl.git
 
 After installing your build's Yocto/OpenEmbedded components:
 
-1. Insert the 'meta-wolfssl' layer location into your build's bblayers.conf
-   file, in the BBLAYERS section:
+1.  Insert the 'meta-wolfssl' layer location into your build's bblayers.conf
+    file, in the BBLAYERS section:
 
-   ```
-   BBLAYERS ?= " \
+    ```
+    BBLAYERS ?= " \
        ...
        /path/to/yocto/poky/meta-wolfssl \
        ...
-   "
-   ```
+    "
+    ```
 
-2. Once the 'meta-wolfssl' layer has been added to your BBLAYERS collection,
-   you then will need to go to the local.conf file located in 
-   meta-wolfssl/conf/. The products that you want to compile will need to be
-   uncommented.
+2.  Once the 'meta-wolfssl' layer has been added to your BBLAYERS collection,
+    you have two options
+   
+    1.  If you want to directly add wolfssl recipes to your image recipe 
+        proceed to step 3.
 
-   As an example if wolfssh is desired the following needs to occur:
-   From "meta-wolfssl" directory
-   ```
-   $ vim conf/layer.conf
-   ```
-   Then look for the text:
-   ```
-   # Uncomment if building wolfssh with wolfssl
-   #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
-   #            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
-   ```
-   Then uncomment by removing the #, it should look like this afterwards
-   ```
-   # Uncomment if building wolfssh with wolfssl
-   BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
+
+    2.  If you want to run `bitbake wolf*` on a particular recipe then it needs 
+        uncommented in `local.conf` located in `meta-wolfssl/conf/`. 
+
+        As an example if wolfssh is desired the following needs to occur:
+        From "meta-wolfssl" directory
+        ```
+        $ vim conf/layer.conf
+        ```
+        Then look for the text:
+        ```
+        # Uncomment if building wolfssh with wolfssl
+        #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
+        #            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
+        ```
+        Then uncomment by removing the #, it should look like this afterwards
+        ```
+        # Uncomment if building wolfssh with wolfssl
+        BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
                ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
-   ```
+        ```
 
-   This needs to be done in order to preform a bitbake operation on any of the 
-   products or tests. You should uncomment products you want to use and 
-   comment out products you don't want to use to avoid uneeded --enable-options
-   in your wolfssl version. wolfssl and wolfclu uncommented by default.
+        This needs to be done in order to preform a bitbake operation on any of the 
+        recipes. 
+        
+        You should make sure to comment out recipes you don't want to use to 
+        avoid uneeded --enable-options in your wolfssl version. wolfssl is 
+        uncommented by default.
 
-3. Once the products that need to be compiled are uncommented,
-   you can build the individual product recipes to make sure they compile
-   successfully:
+        Once the recipes that need to be compiled are uncommented,
+        you can build the individual product/test recipes to make sure they 
+        compile successfully:
 
-   ```
-   $ bitbake wolfssl
-   $ bitbake wolfssh
-   $ bitbake wolfmqtt
-   $ bitbake wolftpm
-   $ bitbake wolfclu
-   ```
-4. Edit your build's local.conf file to install the libraries you would like
-   included (ie: wolfssl, wolfssh, wolfmqtt, wolftpm) by adding a
-   IMAGE_INSTALL:append line:
+        ```
+        $ bitbake wolfssl
+        $ bitbake wolfssh
+        $ bitbake wolfmqtt
+        $ bitbake wolftpm
+        $ bitbake wolfclu
+        ```
+
+3.  Edit your build's local.conf file to install the recipes you would like
+    to include (ie: wolfssl, wolfssh, wolfmqtt, wolftpm) 
+    
+    - For Dunfell and newer versions of Yocto
+    IMAGE_INSTALL:append line:
 
     ```
     IMAGE_INSTALL:append = " wolfssl wolfssh wolfmqtt wolftpm wolfclu "
     ```
+    
+    - For versions of Yocto older than Dunfell
+    IMAGE_INSTALL_append line:
+
+    ```
+    IMAGE_INSTALL_append = " wolfssl wolfssh wolfmqtt wolftpm wolfclu "
+    ```
+
+    This will add the necassary --enable-* options necassary to use your
+    specific combination of recipes.
+
+    If you did step 2.2 make sure you comment out recipes that you don't desire
+    because leaving them uncommented may add unneed --enable-* options in your 
+    build, which could increase the size of the build and turn on uneeded 
+    features.
 
 Once your image has been built, the default location for the wolfSSL library
-on your machine will be in the "/usr/lib" directory and applications in 
-"/usr/bin".
+on your machine will be in the "/usr/lib" directory.
 
 Note: If you need to install the development headers for these libraries, you
 will want to use the "-dev" variant of the package. For example, to install
 both the wolfSSL library and headers into your image, use "wolfssl-dev" along
-with IMAGE_INSTALL_append, ie:
+with IMAGE_INSTALL:append, ie:
 
+- For Dunfell and newer versions of Yocto
+```
+IMAGE_INSTALL:append = "wolfssl-dev"
+```
+
+- For versions of Yocto older than Dunfell
 ```
 IMAGE_INSTALL_append = "wolfssl-dev"
 ```
 
+
 After building your image, you will find wolfSSL headers in the
-"/usr/include" directory.
+"/usr/include" directory and applications in "usr/bin".
 
 Customizing the wolfSSL Library Configuration
 ---------------------------------------------
@@ -195,12 +239,19 @@ $ bitbake wolfcryptbenchmark
 ```
 
 To install these applications into your image, you will need to edit your
-"build/conf/local.conf" file and add them to the "IMAGE_INSTALL_append"
+"build/conf/local.conf" file and add them to the "IMAGE_INSTALL"
 variable. For example, to install the wolfSSL, wolfSSH, and wolfMQTT libraries
 in addition to the wolfCrypt test and benchmark applications:
 
+
+- For Dunfell and newer versions of Yocto
 ```
-IMAGE_INSTALL_append = "wolfssl wolfssh wolfmqtt wolftpm wolfcrypttest wolfcryptbenchmark"
+IMAGE_INSTALL:append = " wolfssl wolfssh wolfmqtt wolftpm wolfclu wolfcrypttest wolfcryptbenchmark "
+```
+
+- For versions of Yocto older than Dunfell
+```
+IMAGE_INSTALL_append = " wolfssl wolfssh wolfmqtt wolftpm wolfclu wolfcrypttest wolfcryptbenchmark "
 ```
 
 When your image builds, these will be installed to the '/usr/bin' system
@@ -213,13 +264,111 @@ Excluding Recipe from Build
 Recipes can be excluded from your build by deleting their respective ".bb" file,
 or by deleting the recipe directory.
 
+Wolfssl-py and Wolfcrypt-py Installation Requirements
+-----------------------------------------------------
+
+To use the python wrapper for wolfssl and wolfcrypt in a yocto build it will
+require python3, python3-cffi and wolfssl are built on the target system.
+
+If you are using older version of yocto (2.x) or (3.x), you will need to download 
+and add the meta-oe and meta-python recipes from openembedded's [meta-openembedded](https://github.com/openembedded/meta-openembedded) to the image.
+
+It will be necassary then to make sure at minimum that the IMAGE_INSTALL:append 
+looks as follows:
+
+- For Dunfell and newer versions of Yocto
+    + if wolfSSL-py is desired on target system
+    ```
+    IMAGE_INSTALL:append = " wolfssl wolfssl-py python3 "
+    ```
+    + if wolfCrypt-py is desired on target system
+    ```
+    IMAGE_INSTALL:append = " wolfssl wolfcrypt-py python3 "
+    ```
+    + if wolfSSL-py and wolfCrypt-py are both desired on target system
+    ```
+    Image_INSTALL:append = " wolfssl wolfssl-py wolfcrypt-py python3 python3-cffi"
+    ```
+
+- For versions of Yocto older than Dunfell
+    + if wolfSSL-py is desired on target system
+    ```
+    IMAGE_INSTALL_append = " wolfssl wolfssl-py python3 "
+    ```
+    + if wolfCrypt-py is desired on target system
+    ```
+    IMAGE_INSTALL_append = " wolfssl wolfcrypt-py python3 "
+    ```
+    + if wolfSSL-py and wolfCrypt-py are both desired on target system
+    ```
+    Image_INSTALL_append = " wolfssl wolfssl-py wolfcrypt-py python3 python3-cffi"
+    ```
+
+Testing Wolfssl-py and Wolfcrypt-py
+-----------------------------------
+
+
+To test the python wrapper for wolfssl and wolfcrypt in a yocto build it will
+require python3, python3-pytest, python3-cffi and wolfssl are built on the target system.
+
+It will be necassary then to make sure at minimum that the IMAGE_INSTALL:append 
+looks as follows:
+
+
+- If wolfSSL-py and wolfCrypt-py are both desired on target system
+
+    + For Dunfell and newer versions of Yocto
+    ```
+    IMAGE_INSTALL:append = " wolfssl wolfssl-py wolfcrypt-py wolf-py-tests python3 python3-cffi python3-pytest"
+    ```
+
+    + For versions of Yocto older than Dunfell
+    ```
+    IMAGE_INSTALL_append = " wolfssl wolfssl-py wolfcrypt-py wolf-py-tests python3 python3-cffi python3-pytest"
+    ```
+
+This places the tests in the root home directory
+```
+$ cd /home/root/wolf-py-tests/
+$ ls wolfcrypt-py-test wolfssl-py-test
+```
+
+navigate into the desired test:
+
+    + for wolfssl-py
+    ```
+    $ cd /home/root/wolf-py-tests/wolfssl-py-test
+
+    ```
+    + for wolfcrypt-py
+    ```
+    $ cd /home/root/wolf-py-tests/wolfcrypt-py-test
+    ```
+
+once in the desired test directory, begin the test by calling pytest
+```
+$ pytest
+```
+
+This should then result in a pass or fail for the desired suit.
+
+If you are testing this with the core-image-minimal yocto build, make sure 
+to add a DNS server to /etc/resolv.conf like such with root perms
+
+```
+echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+```
+
 Maintenance
 -----------
 
 Layer maintainers:
+- wolfSSL Support (<support@wolfssl.com>)
 - Chris Conlon (<chris@wolfssl.com>)
 - Jacob Barthelmeh (<jacob@wolfssl.com>)
 
+Website
+-------
 https://www.wolfssl.com
 
 License

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,30 +1,95 @@
 # We have a conf and classes directory, add to BBPATH
 BBPATH := "${LAYERDIR}:${BBPATH}"
 
-
 # We have a packages directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssl/*.bb \
             ${LAYERDIR}/recipes-wolfssl/wolfssl/*.bbappend"
 
-#Comment out if you don't want to use wolfclu 
-BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfclu/*.bb \
-            ${LAYERDIR}/recipes-wolfssl/wolfclu/*.bbappend"                                                 
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfssl', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssl/*.bb ${LAYERDIR}/recipes-wolfssl/wolfssl/*.bbappend', \
+                                 '', d)}"
 
-# Uncomment if wanting to use example tests                                                 
-#BBFILES += "${LAYERDIR}/recipes-examples/*/*/*.bb \
-#            ${LAYERDIR}/recipes-examples/*/*/*.bbappend"
+#Comment out if you don't want to use wolfclu 
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfclu/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfclu/*.bbappend"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfclu', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfclu/*.bb ${LAYERDIR}/recipes-wolfssl/wolfclu/*.bbappend', \
+                                 '', d)}"
+
+# Uncomment if wanting to use example test/benchmark for wolfcrypt                                                
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb \
+#             ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bbappend" 
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb \
+#             ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bbappend" 
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfcryptbenchmark', \
+                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bb ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcryptbenchmark/*.bbappend', \
+                                 '', d)}"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfcrypttest', \
+                                 '${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bb ${LAYERDIR}/recipes-examples/wolfcrypt/wolfcrypttest/*.bbappend' , \
+                                 '', d)}"
+
 
 # Uncomment if building wolfssh with wolfssl
 #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb \
 #            ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend"
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfssh', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssh/*.bb ${LAYERDIR}/recipes-wolfssl/wolfssh/*.bbappend', \
+                                 '', d)}"
+
 
 # Uncomment if building wolfmqtt with wolfssl
 #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bb \
 #            ${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bbappend"
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfmqtt', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bb ${LAYERDIR}/recipes-wolfssl/wolfmqtt/*.bbappend', \
+                                 '', d)}"
+
 
 # Uncomment if building wolftpm with wolfssl
 #BBFILES += "${LAYERDIR}/recipes-wolfssl/wolftpm/*.bb \
-#            ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend"
+#           ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend"
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolftpm', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolftpm/*.bb ${LAYERDIR}/recipes-wolfssl/wolftpm/*.bbappend', \
+                                 '', d)}"
+
+# Uncomment if building wolfssl-py
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bbappend"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfssl-py', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bb ${LAYERDIR}/recipes-wolfssl/wolfssl-py/*.bbappend', \
+                                 '', d)}"
+
+# Uncomment if building wolfcrypt-py
+#BBFILES += "${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bb \
+#            ${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bbappend"
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolfcrypt-py', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bb ${LAYERDIR}/recipes-wolfssl/wolfcrypt-py/*.bbappend', \
+                                 '', d)}"
+
+
+# Uncomment if wanting to use example tests for wolfssl-py/wolfcrypt-py                                                 
+#BBFILES += "${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb \
+#            ${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bbappend" 
+
+BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
+                                 'wolf-py-tests', \
+                                 '${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bb ${LAYERDIR}/recipes-examples/wolfssl-py/wolf-py-tests/*.bbappend', \
+                                 '', d)}"
+
 
 
 # Uncomment if building bind with wolfSSL.
@@ -58,9 +123,8 @@ BBFILE_COLLECTIONS += "wolfssl"
 BBFILE_PATTERN_wolfssl := "^${LAYERDIR}/"
 BBFILE_PRIORITY_wolfssl = "5"
 
-# Yocto manual recommends a space before this list to prevent conflicts
-IMAGE_INSTALL_append = " wolfssl"
+# BitBake user manual: "You must control all spacing when you use the override
+# syntax." Thus, we need a leading space below.
 
 # Versions of OpenEmbedded-Core which layer has been tested against
-LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus dunfell hardknott \
-                              gatesgarth"
+LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus hardknott gatesgarth dunfell kirkstone nanbield"

--- a/recipes-connectivity/README.md
+++ b/recipes-connectivity/README.md
@@ -1,0 +1,67 @@
+Supported Ports
+===============
+
+In this section these projects have been ported to work with specific versions
+of packages shipped with yocto to be used with wolfSSL
+
+BIND
+----
+
+This supports using `BIND` version: 9.11.22, which was shipped with Yocto Dunfell.
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building bind with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-connectivity/bind/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building bind with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-connectivity/bind/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `BIND` and include the `wolfSSL`
+    package or preform `bitbake bind`
+
+OpenSSH
+-------
+
+This supports using `OpenSSH` version: 8.5p1, which was shipped with Yocto Hardknott
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building OpenSSH with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-connectivity/openssh/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building OpenSSH with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-connectivity/openssh/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `OpenSSH` and include the `wolfSSL`
+    package or preform `bitbake openssh`
+
+
+Socat
+-----
+
+This supports using `Socat` version: 1.7.3.4, which was shipped with Yocto Dunfell
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building socat with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-connectivity/socat/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building socat with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-connectivity/socat/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `Socat` and include the `wolfSSL`
+    package or preform `bitbake socat`
+

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
@@ -5,22 +5,41 @@ HOMEPAGE = "https://www.wolfssl.com"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "x11/applications"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}:"
-
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://benchmark.c;beginline=1;endline=20;md5=aca0c406899b7421c67598ba3f55d1a5"
-
-DEPENDS += "wolfssl"
-WOLFCRYPT_V="5.6.6"
-SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;tag=v${WOLFCRYPT_V}-stable;"
-
 S = "${WORKDIR}/git/wolfcrypt/benchmark"
+DEPENDS += "wolfssl"
 
-do_compile() {
-    ${CC} ${CFLAGS} -DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DUSE_FLAT_BENCHMARK_H -DBENCH_EMBEDDED -Wall -include wolfssl/options.h -o wolfcryptbenchmark ${S}/benchmark.c -lwolfssl ${LDFLAGS}
-}
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=66596ad9e1d7efa8479656872cf09c9c1870a02e"
 
-do_install() {
-    install -d ${D}${bindir}
-    install -m 0755 ${S}/wolfcryptbenchmark ${D}${bindir}
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+WOLFCRYPT_BENCHMARK_DIR = "${datadir}/wolfcrypt-benchmark"
+WOLFCRYPT_BENCHMARK_INSTALL_DIR = "${D}${WOLFCRYPT_BENCHMARK_DIR}"
+WOLFCRYPT_BENCHMARK_README = "README.txt"
+WOLFCRYPT_BENCHMARK_README_DIR = "${WOLFCRYPT_BENCHMARK_INSTALL_DIR}/${WOLFCRYPT_BENCHMARK_README}"
+
+python () {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    wolfcrypt_benchmark_dir = d.getVar('WOLFCRYPT_BENCHMARK_DIR', True)
+    wolfcrypt_benchmark_install_dir = d.getVar('WOLFCRYPT_BENCHMARK_INSTALL_DIR', True)
+    wolfcrypt_benchmark_readme_dir = d.getVar('WOLFCRYPT_BENCHMARK_README_DIR', True)
+
+    bb.note("Installing dummy file for wolfCrypt benchmark example")
+    installDir = 'install -m 0755 -d "%s"\n' % wolfcrypt_benchmark_install_dir
+    makeDummy = 'echo "This is a dummy package" > "%s"\n' % wolfcrypt_benchmark_readme_dir
+
+    d.appendVar('do_install', installDir)
+    d.appendVar('do_install', makeDummy)
+
+    pn = d.getVar('PN', True)
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        files_var_name = 'FILES_' + pn
+    else:
+        files_var_name = 'FILES:' + pn
+
+    current_files = d.getVar(files_var_name, True) or ""
+    new_files = current_files + ' ' + wolfcrypt_benchmark_dir + '/*'
+    d.setVar(files_var_name, new_files)
 }

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfssl_%.bbappend
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfssl_%.bbappend
@@ -1,0 +1,26 @@
+WOLFCRYPT_BENCHMARK_DIR = "${B}/wolfcrypt/benchmark/.libs"
+WOLFCRYPT_BENCHMARK = "benchmark"
+WOLFCRYPT_BENCHMARK_YOCTO = "wolfcryptbenchmark"
+WOLFCRYPT_INSTALL_DIR = "${D}${bindir}"
+
+python () {
+    # Get the environment variables WOLFCRYPT_BENCHMARK_DIR, WOLFCRYPT_BENCHMARK,
+    #   WOLFCRYPT_BENCHMARK_YOCTO, and WOLFCRYPT_INSTALL_DIR
+    wolfcrypt_benchmark_dir = d.getVar('WOLFCRYPT_BENCHMARK_DIR', True)
+    wolfcrypt_benchmark = d.getVar('WOLFCRYPT_BENCHMARK', True)
+    wolfcrypt_benchmark_yocto = d.getVar('WOLFCRYPT_BENCHMARK_YOCTO', True)
+    wolfcrypt_install_dir = d.getVar('WOLFCRYPT_INSTALL_DIR', True)
+
+    bbnote = 'bbnote "Installing wolfCrypt Benchmarks"\n'
+    installDir = 'install -m 0755 -d "%s"\n' % (wolfcrypt_install_dir)
+    cpBenchmark = 'cp "%s/%s" "%s/%s"\n' % (wolfcrypt_benchmark_dir, wolfcrypt_benchmark, wolfcrypt_install_dir, wolfcrypt_benchmark_yocto)
+
+    d.appendVar('do_install', bbnote)
+    d.appendVar('do_install', installDir)
+    d.appendVar('do_install', cpBenchmark)
+}
+
+
+
+TARGET_CFLAGS += "-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DBENCH_EMBEDDED"
+

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
@@ -5,22 +5,43 @@ HOMEPAGE = "https://www.wolfssl.com"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "x11/applications"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}:"
-
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://test.c;beginline=1;endline=20;md5=61d63fb8b820bae4d85beb53e7acf340"
-
+S = "${WORKDIR}/git/wolfcrypt/test"
 DEPENDS += "wolfssl"
 
-WOLFCRYPT_V="5.6.6"
-SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;tag=v${WOLFCRYPT_V}-stable;"
-S = "${WORKDIR}/git/wolfcrypt/test"
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=66596ad9e1d7efa8479656872cf09c9c1870a02e"
 
-do_compile() {
-    ${CC} ${CFLAGS} -DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DUSE_FLAT_TEST_H -Wall -include wolfssl/options.h -o wolfcrypttest ${S}/test.c -lwolfssl ${LDFLAGS}
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+WOLFCRYPT_TEST_DIR = "${datadir}/wolfcrypt-test"
+WOLFCRYPT_TEST_INSTALL_DIR = "${D}${WOLFCRYPT_TEST_DIR}"
+WOLFCRYPT_TEST_README = "README.txt"
+WOLFCRYPT_TEST_README_DIR = "${WOLFCRYPT_TEST_INSTALL_DIR}/${WOLFCRYPT_TEST_README}"
+
+python () {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    wolfcrypt_test_dir = d.getVar('WOLFCRYPT_TEST_DIR', True)
+    wolfcrypt_test_install_dir = d.getVar('WOLFCRYPT_TEST_INSTALL_DIR', True)
+    wolfcrypt_test_readme_dir = d.getVar('WOLFCRYPT_TEST_README_DIR', True)
+
+    bb.note("Installing dummy file for wolfCrypt test example")
+    installDir = 'install -m 0755 -d "%s"\n' % wolfcrypt_test_install_dir
+    makeDummy = 'echo "This is a dummy package" > "%s"\n' % wolfcrypt_test_readme_dir
+
+    d.appendVar('do_install', installDir)
+    d.appendVar('do_install', makeDummy)
+
+    pn = d.getVar('PN', True)
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        files_var_name = 'FILES_' + pn
+    else:
+        files_var_name = 'FILES:' + pn
+    
+    current_files = d.getVar(files_var_name, True) or ""
+    new_files = current_files + ' ' + wolfcrypt_test_dir + '/*'
+    d.setVar(files_var_name, new_files)
 }
 
-do_install() {
-    install -d ${D}${bindir}
-    install -m 0755 ${S}/wolfcrypttest ${D}${bindir}
-}

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfssl_%.bbappend
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfssl_%.bbappend
@@ -1,0 +1,23 @@
+WOLFCRYPT_TEST_DIR = "${B}/wolfcrypt/test/.libs"
+WOLFCRYPT_TEST = "testwolfcrypt"
+WOLFCRYPT_TEST_YOCTO = "wolfcrypttest"
+WOLFCRYPT_INSTALL_DIR = "${D}${bindir}"
+
+python () {
+    # Get the environment variables WOLFCRYPT_TEST_DIR, WOLFCRYPT_TEST,
+    #   WOLFCRYPT_TEST_YOCTO, and WOLFCRYPT_INSTALL_DIR
+    wolfcrypt_test_dir = d.getVar('WOLFCRYPT_TEST_DIR', True)
+    wolfcrypt_test = d.getVar('WOLFCRYPT_TEST', True)
+    wolfcrypt_test_yocto = d.getVar('WOLFCRYPT_TEST_YOCTO', True)
+    wolfcrypt_install_dir = d.getVar('WOLFCRYPT_INSTALL_DIR', True)
+
+    bbnote = 'bbnote "Installing wolfCrypt Tests"\n'
+    installDir = 'install -m 0755 -d "%s"\n' % (wolfcrypt_install_dir)
+    cpBenchmark = 'cp "%s/%s" "%s/%s"\n' % (wolfcrypt_test_dir, wolfcrypt_test, wolfcrypt_install_dir, wolfcrypt_test_yocto)
+
+    d.appendVar('do_install', bbnote)
+    d.appendVar('do_install', installDir)
+    d.appendVar('do_install', cpBenchmark)
+}
+
+TARGET_CFLAGS += "-DUSE_CERT_BUFFERS_2048 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_RSA_KEY_CHECK -DNO_WRITE_TEMP_FILES"

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
@@ -1,0 +1,52 @@
+SUMMARY = "wolfSSL Python, a.k.a. wolfssl, is a Python module that encapsulates \
+           wolfSSL's SSL/TLS library."
+DESCRIPTION = "The wolfSSL SSL/TLS library is a lightweight, portable, \
+               C-language-based library targeted at IoT, embedded, and RTOS \
+               environments primarily because of its size, speed, and feature \
+               set. It works seamlessly in desktop, enterprise, and cloud \
+               environments as well."
+HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
+BUGTRACKER = "https://github.com/wolfSSL/wolfssl-py/issues"
+SECTION = "libs"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
+
+SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=0a8a76c6d426289d9019e10d02db9a5af051fba8"
+
+DEPENDS += " wolfssl-py \
+             wolfcrypt-py \
+           "  
+
+S = "${WORKDIR}/git"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+WOLFCRYPT_TEST_PY_DIR = "/home/root/wolf-py-tests"
+WOLFCRYPT_TEST_PY_INSTALL_DIR = "${D}${WOLFCRYPT_TEST_PY_DIR}"
+WOLFCRYPT_TEST_PY_README = "README.txt"
+WOLFCRYPT_TEST_PY_README_DIR = "${WOLFCRYPT_TEST_PY_INSTALL_DIR}/${WOLFCRYPT_TEST_PY_README}"
+
+python () {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    wolfcrypt_test_py_dir = d.getVar('WOLFCRYPT_TEST_PY_DIR', True)
+    wolfcrypt_test_py_install_dir = d.getVar('WOLFCRYPT_TEST_PY_INSTALL_DIR', True)
+    wolfcrypt_test_py_readme_dir = d.getVar('WOLFCRYPT_TEST_PY_README_DIR', True)
+
+    bb.note("Installing dummy file for wolfCrypt test example")
+    installDir = 'install -m 0755 -d "%s"\n' % wolfcrypt_test_py_install_dir
+    makeDummy = 'echo "This is a dummy package" > "%s"\n' % wolfcrypt_test_py_readme_dir
+
+    d.appendVar('do_install', installDir)
+    d.appendVar('do_install', makeDummy)
+
+    pn = d.getVar('PN', True)
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        files_var_name = 'FILES_' + pn
+    else:
+        files_var_name = 'FILES:' + pn
+    
+    current_files = d.getVar(files_var_name, True) or ""
+    new_files = current_files + ' ' + wolfcrypt_test_py_dir + '/*'
+    d.setVar(files_var_name, new_files)
+}

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolfcrypt-py_%.bbappend
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolfcrypt-py_%.bbappend
@@ -1,0 +1,32 @@
+WOLFCRYPT_PY_TEST_DIR = "${S}"
+WOLFCRYPT_PY_DIR = "/home/root/wolf-py-tests/wolfcrypt-py-test"
+WOLFCRYPT_PY_TEST_TARGET_DIR = "${D}${WOLFCRYPT_PY_DIR}"
+
+python () {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    wolfcrypt_py_test_dir = d.getVar('WOLFCRYPT_PY_TEST_DIR', True)
+    wolfcrypt_py_test_target_dir = d.getVar('WOLFCRYPT_PY_TEST_TARGET_DIR', True)
+
+    bb.note("Installing Certs Directory for wolf-py Tests")
+    installDirCmd = 'install -m 0755 -d "%s"\n' % wolfcrypt_py_test_target_dir
+    cpWolfcryptPyTestCmd = 'cp -r %s/* %s\n' % (wolfcrypt_py_test_dir, wolfcrypt_py_test_target_dir)
+
+    d.appendVar('do_install', installDirCmd)
+    d.appendVar('do_install', cpWolfcryptPyTestCmd)
+
+
+    pn = d.getVar('PN', True)
+    wolfcrypt_py_dir = d.getVar('WOLFCRYPT_PY_DIR', True)
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        files_var_name = 'FILES_' + pn
+    else:
+        files_var_name = 'FILES:' + pn
+    
+    current_files = d.getVar(files_var_name, True) or ""
+    new_files = current_files + ' ' + wolfcrypt_py_dir + '/*'
+    d.setVar(files_var_name, new_files)
+}
+
+# Python Specific option
+export PYTHONDONTWRITEBYTECODE = "1"
+

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl-py_%.bbappend
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl-py_%.bbappend
@@ -1,0 +1,34 @@
+WOLFSSL_PY_TEST_DIR = "${S}"                                                  
+WOLFSSL_PY_DIR = "/home/root/wolf-py-tests/wolfssl-py-test"
+WOLFSSL_PY_TEST_TARGET_DIR = "${D}${WOLFSSL_PY_DIR}"
+
+python () {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    wolfssl_py_test_dir = d.getVar('WOLFSSL_PY_TEST_DIR', True)
+    wolfssl_py_test_target_dir = d.getVar('WOLFSSL_PY_TEST_TARGET_DIR', True)
+
+    bb.note("Installing Certs Directory for wolf-py Tests")
+    installDir = 'install -m 0755 -d "%s"\n' % (wolfssl_py_test_target_dir)
+    cpWolfsslPyTest = 'cp -r %s/* %s\n' % (wolfssl_py_test_dir, wolfssl_py_test_target_dir)
+
+    d.appendVar('do_install', installDir)
+    d.appendVar('do_install', cpWolfsslPyTest)
+
+    # Append to FILES:${PN} within the Python function
+    files_var = 'FILES:' + d.getVar('PN', True)
+    wolfssl_py_test_files = wolfssl_py_test_target_dir + '/*'
+
+    pn = d.getVar('PN', True)
+    wolfssl_py_dir = d.getVar('WOLFSSL_PY_DIR', True)
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        files_var_name = 'FILES_' + pn
+    else:
+        files_var_name = 'FILES:' + pn    
+    
+    current_files = d.getVar(files_var_name, True) or ""
+    new_files = current_files + ' ' + wolfssl_py_dir + '/*'
+    d.setVar(files_var_name, new_files)
+}
+
+# Python Specific option                                                        
+export PYTHONDONTWRITEBYTECODE = "1" 

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl_%.bbappend
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolfssl_%.bbappend
@@ -1,0 +1,32 @@
+WOLFSSL_PY_TEST_CERTS_DIR = "/home/root/wolf-py-tests/certs"
+WOLFSSL_PY_CERTS_DIR = "/certs"
+WOLFSSL_PY_CERTS_INSTALL_DIR = "${D}${WOLFSSL_PY_TEST_CERTS_DIR}"
+WOLFSSL_PY_CERTS_SOURCE_DIR = "${S}${WOLFSSL_PY_CERTS_DIR}"
+
+python () {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    wolfssl_py_certs_install_dir = d.getVar('WOLFSSL_PY_CERTS_INSTALL_DIR', True)
+    wolfssl_py_certs_source_dir = d.getVar('WOLFSSL_PY_CERTS_SOURCE_DIR', True)
+
+    bbnote = 'bbnote "Installing Certs Directory for wolf-py Tests"\n'
+    installDir = 'install -m 0755 -d "%s"\n' % (wolfssl_py_certs_install_dir)
+    cpDer = 'cp -r %s/*.der %s\n' % (wolfssl_py_certs_source_dir, wolfssl_py_certs_install_dir)
+    cpPem = 'cp -r %s/*.pem %s\n' % (wolfssl_py_certs_source_dir, wolfssl_py_certs_install_dir)
+
+    d.appendVar('do_install', bbnote)
+    d.appendVar('do_install', installDir)
+    d.appendVar('do_install', cpDer)
+    d.appendVar('do_install', cpPem)
+
+
+    pn = d.getVar('PN', True)
+    wolfssl_py_test_certs_dir = d.getVar('WOLFSSL_PY_TEST_CERTS_DIR', True)
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        files_var_name = 'FILES_' + pn
+    else:
+        files_var_name = 'FILES:' + pn
+    
+    current_files = d.getVar(files_var_name, True) or ""
+    new_files = current_files + ' ' + wolfssl_py_test_certs_dir + '/*'
+    d.setVar(files_var_name, new_files)
+}

--- a/recipes-extended/README.md
+++ b/recipes-extended/README.md
@@ -1,0 +1,26 @@
+Supported Ports
+===============
+
+In this section these projects have been ported to work with specific versions
+of packages shipped with yocto to be used with wolfSSL
+
+Rsyslog
+-----
+
+This supports using `Rsyslog` version: 8.2106.0, which was shipped with Yocto Honister
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building rsyslog with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-extended/rsyslog/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building rsyslog with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-extended/rsyslog/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `Rsyslog` and include the `wolfSSL`
+    package or preform `bitbake Rsyslog`
+

--- a/recipes-protocols/README.md
+++ b/recipes-protocols/README.md
@@ -1,0 +1,26 @@
+Supported Ports
+===============
+
+In this section these projects have been ported to work with specific versions
+of packages shipped with yocto to be used with wolfSSL
+
+Net-snmp
+-----
+
+This supports using `Net-snmp` version: 5.9, which was shipped with Yocto Gatesgarth 
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building net-snmp with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-protocols/net-snmp/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building net-snmp with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-protocols/net-snmp/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `Net-snmp` and include the `wolfSSL`
+    package or preform `bitbake net-snmp`
+

--- a/recipes-support/README.md
+++ b/recipes-support/README.md
@@ -1,0 +1,88 @@
+Supported Ports
+===============
+
+In this section these projects have been ported to work with specific versions
+of packages shipped with yocto to be used with wolfSSL
+
+Curl
+-----
+
+This supports using `curl` version: 7.82.0, which was shipped with Yocto Kirkstone 
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building curl with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-support/curl/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building curl with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-support/curl/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `curl` and include the `wolfSSL`
+    package or preform `bitbake curl`
+
+    
+libssh2    
+-----
+
+This supports using `libssh2` version: 1.9.0, which was shipped with Yocto Dunfell 
+and Gatesgarth
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building libssh2 with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-support/libssh2/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building libssh2 with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-support/libssh2/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `libssh2` and include the `wolfSSL`
+    package or preform `bitbake libssh2`
+    
+strongSwan
+-----
+
+This supports using `strongSwan` version: 5.9.4, which was shipped with Yocto Honister 
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building strongSwan with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-support/strongswan/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building strongSwan with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-support/strongswan/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `strongSwan` and include the `wolfSSL`
+    package or preform `bitbake strongswan`
+    
+tcpdump
+-----
+
+This supports using `tcpdump` version: 4.9.3, which was shipped with Yocto Warrior, 
+Zeus, Dunfell, and Gatesgarth 
+
+- Usage:
+    Change the line in the `meta-wolfssl/conf/layer.conf` from:
+    ```
+    # Uncomment if building tcpdump with wolfSSL.
+    #BBFILES += "${LAYERDIR}/recipes-support/tcpdump/*.bbappend"
+    ```
+    to:
+    ```
+    # Uncomment if building tcpdump with wolfSSL.
+    BBFILES += "${LAYERDIR}/recipes-support/tcpdump/*.bbappend"
+    ```
+    
+    Then just compile the image that use's `tcpdumb` and include the `wolfSSL`
+    package or preform `bitbake tcpdumb`

--- a/recipes-wolfssl/wolfclu/wolfclu_0.1.5.bb
+++ b/recipes-wolfssl/wolfclu/wolfclu_0.1.5.bb
@@ -4,17 +4,15 @@ DESCRIPTION = "wolfCLU is a lightweight command line utility written in C and \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfclu"
 BUGTRACKER = "https://github.com/wolfssl/wolfclu/issues"
 SECTION = "bin"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 PROVIDES += "wolfclu"
 RPROVIDES_${PN} = "wolfclu"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfclu.git;nobranch=1;protocol=https;tag=v${PV}-stable;"
+SRC_URI = "git://github.com/wolfssl/wolfclu.git;nobranch=1;protocol=https;rev=c862879aa92bba201b42ea87f5008f53febf4be3"
 
 S = "${WORKDIR}/git"
 
@@ -24,7 +22,23 @@ EXTRA_OECONF = "--with-wolfssl=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
 
 BBCLASSEXTEND += "native nativesdk"
 
-do_configure_prepend() {
-    (cd ${S}; ./autogen.sh; cd -)
+python() {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    autogen_command = 'cd ${S}; ./autogen.sh'
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        # For Dunfell and earlier
+        d.appendVar('do_configure_prepend', autogen_command)
+    else:
+        # For Kirkstone and later
+        d.appendVar('do_configure:prepend', autogen_command)
 }
+
+# Add reproducible build flags
+export CFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export CXXFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export LDFLAGS += ' -Wl,--build-id=none'
+
+# Ensure consistent locale
+export LC_ALL = "C"
+
 

--- a/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.6.0.bb
+++ b/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.6.0.bb
@@ -1,0 +1,42 @@
+SUMMARY = "wolfCrypt Python, a.k.a. wolfcrypt is a Python module that \
+           encapsulates wolfSSL's wolfCrypt API."
+           
+DESCRIPTION = "wolfCrypt is a lightweight, portable, C-language-based crypto \
+               library targeted at IoT, embedded, and RTOS environments \
+               primarily because of its size, speed, and feature set. It works \
+               seamlessly in desktop, enterprise, and cloud environments as \
+               well. It is the crypto engine behind wolfSSL's embedded ssl \
+               library."
+HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
+BUGTRACKER = "https://github.com/wolfSSL/wolfcrypt-py/issues"
+SECTION = "libs"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
+
+SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=1c242652a799190b55cc20964135297357e00b67"
+
+
+DEPENDS += " wolfssl \
+            python3-pip-native \
+            python3-cffi-native \
+            python3-cffi \
+            python3-native \
+            python3 \
+            "
+
+inherit setuptools3  
+
+S = "${WORKDIR}/git"
+
+WOLFSSL_YOCTO_DIR = "${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
+
+
+export USE_LOCAL_WOLFSSL="${WOLFSSL_YOCTO_DIR}"
+# Add reproducible build flags
+CFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+CXXFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+LDFLAGS += " -Wl,--build-id=none"
+
+
+# Ensure consistent locale for build reproducibility
+export LC_ALL = "C"

--- a/recipes-wolfssl/wolfcrypt-py/wolfssl_%.bbappend
+++ b/recipes-wolfssl/wolfcrypt-py/wolfssl_%.bbappend
@@ -1,0 +1,2 @@
+EXTRA_OECONF += " --enable-aes --enable-aesctr --enable-des3 --enable-chacha --enable-aesgcm-stream --enable-aesgcm --enable-sha --enable-sha384 --enable-sha512 --enable-sha3 --enable-hkdf --enable-rsa --enable-rsapss --enable-ecc --enable-ed25519 --enable-ed448 --enable-curve25519 --enable-keygen --enable-pwdbased --enable-pkcs7 --enable-dtls --enable-tls13 --enable-tlsx"
+

--- a/recipes-wolfssl/wolfmqtt/wolfmqtt_1.18.0.bb
+++ b/recipes-wolfssl/wolfmqtt/wolfmqtt_1.18.0.bb
@@ -7,18 +7,35 @@ DESCRIPTION = "wolfMQTT is a client library implementation of the MQTT \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfmqtt"
 BUGTRACKER = "https://github.com/wolfssl/wolfmqtt/issues"
 SECTION = "libs"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2c1c00f9d3ed9e24fa69b932b7e7aff2"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfMQTT.git;protocol=https;tag=v${PV}"
+SRC_URI = "git://github.com/wolfssl/wolfMQTT.git;nobranch=1;protocol=https;rev=91b01f4be412fff883374168aa4da2bd00d2968c"
+
 
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 
 EXTRA_OECONF = "--with-libwolfssl-prefix=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
-do_configure_prepend() {
-    (cd ${S}; ./autogen.sh; cd -)
+
+python() {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    autogen_command = 'cd ${S}; ./autogen.sh'
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        # For Dunfell and earlier
+        d.appendVar('do_configure_prepend', autogen_command)
+    else:
+        # For Kirkstone and later
+        d.appendVar('do_configure:prepend', autogen_command)
 }
+
+# Add reproducible build flags
+export CFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export CXXFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export LDFLAGS += ' -Wl,--build-id=none'
+
+# Ensure consistent locale                                                      
+export LC_ALL = "C" 

--- a/recipes-wolfssl/wolfssh/wolfssh_1.4.15.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.4.15.bb
@@ -6,22 +6,34 @@ DESCRIPTION = "wolfSSH is a lightweight SSHv2 library written in ANSI C and \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssh"
 BUGTRACKER = "https://github.com/wolfssl/wolfssh/issues"
 SECTION = "libs"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSING;md5=2c2d0ee3db6ceba278dd43212ed03733"
 
-DEPENDS += "wolfssl virtual/crypt"
+DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssh.git;protocol=https;tag=v${PV}-stable"
+SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=60a29602e5893fd4e2ca0f4b6e2e05c6324154ed"
 
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig
 
-EXTRA_OECONF = "--with-wolfssl=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr \
-                --enable-certs --enable-sshd --enable-sftp --enable-scp"
-CPPFLAGS_append = "-DWOLFSSH_NO_FPKI"
+EXTRA_OECONF = "--with-wolfssl=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
 
-do_configure_prepend() {
-    (cd ${S}; ./autogen.sh; cd -)
+python() {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    autogen_command = 'cd ${S}; ./autogen.sh'
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        # For Dunfell and earlier
+        d.appendVar('do_configure_prepend', autogen_command)
+    else:
+        # For Kirkstone and later
+        d.appendVar('do_configure:prepend', autogen_command)
 }
 
+# Add reproducible build flags
+export CFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export CXXFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export LDFLAGS += ' -Wl,--build-id=none'
+
+# Ensure consistent locale                                                      
+export LC_ALL = "C" 

--- a/recipes-wolfssl/wolfssh/wolfssl_%.bbappend
+++ b/recipes-wolfssl/wolfssh/wolfssl_%.bbappend
@@ -1,3 +1,2 @@
-EXTRA_OECONF += "--enable-ssh --enable-keygen --enable-certext --enable-certgen --disable-examples"
-CPPFLAGS_append += "-DWOLFSSL_FPKI -DWOLFSSL_IP_ALT_NAME -DWOLFSSL_ALT_NAMES -DNO_WOLFSSL_DIR -DWOLFSSL_PUBLIC_ASN"
+EXTRA_OECONF += "--enable-ssh"
 

--- a/recipes-wolfssl/wolfssl-py/wolfssl-py_5.6.0.bb
+++ b/recipes-wolfssl/wolfssl-py/wolfssl-py_5.6.0.bb
@@ -1,0 +1,43 @@
+SUMMARY = "wolfSSL Python, a.k.a. wolfssl, is a Python module that encapsulates \
+           wolfSSL's SSL/TLS library."
+DESCRIPTION = "The wolfSSL SSL/TLS library is a lightweight, portable, \
+               C-language-based library targeted at IoT, embedded, and RTOS \
+               environments primarily because of its size, speed, and feature \
+               set. It works seamlessly in desktop, enterprise, and cloud \
+               environments as well."
+HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
+BUGTRACKER = "https://github.com/wolfSSL/wolfssl-py/issues"
+SECTION = "libs"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
+
+SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=0a8a76c6d426289d9019e10d02db9a5af051fba8"
+
+
+DEPENDS += " wolfssl \
+             python3-pip-native \
+             python3-cffi-native \
+             python3-cffi \
+             python3-native \
+             python3 \ 
+           "
+
+RDEPENDS_${PN} += " python3 \
+                    python3-cffi \
+                  "
+
+inherit setuptools3  
+
+S = "${WORKDIR}/git"
+
+WOLFSSL_YOCTO_DIR = "${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
+
+export USE_LOCAL_WOLFSSL="${WOLFSSL_YOCTO_DIR}"
+
+# Add reproducible build flags
+CFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+CXXFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."
+LDFLAGS += " -Wl,--build-id=none"
+
+# Ensure consistent locale for build reproducibility
+export LC_ALL = "C"

--- a/recipes-wolfssl/wolfssl-py/wolfssl_%.bbappend
+++ b/recipes-wolfssl/wolfssl-py/wolfssl_%.bbappend
@@ -1,0 +1,3 @@
+EXTRA_OECONF += "--enable-sni --enable-opensslextra --enable-opensslall --enable-dtls13 --enable-dtls --enable-crl --enable-tlsx --enable-secure-renegotiation"
+
+TARGET_CFLAGS += "-DKEEP_PEER_CERT -DFP_MAX_BITS=8192 -DHAVE_EX_DATA -DOPENSSL_COMPATIBLE_DEFAULTS"

--- a/recipes-wolfssl/wolfssl/wolfssl_5.6.6.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.6.6.bb
@@ -1,28 +1,34 @@
 SUMMARY = "wolfSSL Lightweight Embedded SSL/TLS Library"
-DESCRIPTION = "wolfSSL is a lightweight SSL/TLS library written in C and \
-               optimized for embedded and RTOS environments. It can be up \
-               to 20 times smaller than OpenSSL while still supporting \
-               a full TLS client and server, up to TLS 1.3"
-HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
+DESCRIPTION = "wolfSSL is a lightweight SSL/TLS library written in C and optimized for embedded and RTOS environments. It supports a full TLS client and server, up to TLS 1.3."
+HOMEPAGE = "https://www.wolfssl.com/products/wolfssl/"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "libs"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 DEPENDS += "util-linux-native"
 
-PROVIDES += "cyassl"
-RPROVIDES_${PN} = "cyassl"
 PROVIDES += "wolfssl"
 RPROVIDES_${PN} = "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;tag=v${PV}-stable;"
+SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=66596ad9e1d7efa8479656872cf09c9c1870a02e"
 
 S = "${WORKDIR}/git"
 
+
 inherit autotools pkgconfig
 
-do_configure_prepend() {
-    (cd ${S}; ./autogen.sh; cd -)
+# Approach: Use Python to dynamically set function content based on Yocto version
+python() {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    autogen_command = 'cd ${S}; ./autogen.sh'
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        # For Dunfell and earlier
+        d.appendVar('do_configure_prepend', autogen_command)
+    else:
+        # For Kirkstone and later
+        d.appendVar('do_configure:prepend', autogen_command)
 }
 
-BBCLASSEXTEND += "native nativesdk"
+
+BBCLASSEXTEND = "native nativesdk"
+EXTRA_OECONF += "--enable-reproducible-build"

--- a/recipes-wolfssl/wolftpm/wolftpm_3.1.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_3.1.0.bb
@@ -7,12 +7,12 @@ DESCRIPTION = "wolfTPM is a portable TPM 2.0 project, designed for embedded \
 HOMEPAGE = "https://www.wolfssl.com/products/wolftpm"
 BUGTRACKER = "https://github.com/wolfssl/wolftpm/issues"
 SECTION = "libs"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfTPM.git;protocol=https;tag=v${PV}"
+SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=e54734a3ab2507fbba378567d16aa3e27c54655b"
 
 S = "${WORKDIR}/git"
 
@@ -20,6 +20,21 @@ inherit autotools pkgconfig
 
 EXTRA_OECONF = "--with-wolfcrypt=${COMPONENTS_DIR}/${PACKAGE_ARCH}/wolfssl/usr"
 
-do_configure_prepend() {
-    (cd ${S}; ./autogen.sh; cd -)
+python() {
+    distro_version = d.getVar('DISTRO_VERSION', True)
+    autogen_command = 'cd ${S}; ./autogen.sh'
+    if distro_version and (distro_version.startswith('2.') or distro_version.startswith('3.')):
+        # For Dunfell and earlier
+        d.appendVar('do_configure_prepend', autogen_command)
+    else:
+        # For Kirkstone and later
+        d.appendVar('do_configure:prepend', autogen_command)
 }
+
+# Add reproducible build flags
+export CFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export CXXFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'
+export LDFLAGS += ' -Wl,--build-id=none'
+
+# Ensure consistent locale                                                      
+export LC_ALL = "C" 


### PR DESCRIPTION
This is a draft preview for a PR that is intended to have yocto 4.x and newer and yocto 2.x/3.x compatible recipes so that we only need to keep track of 1 branch effectively halving the workload of maintaining meta-wolfssl.

This is done by using python calls inside the .bb/.bbappend files so that appropriate syntax is conditionally used based on the distro of yocto being used to compile at that moment in time.

I have updated the readme according and tested this on the Yocto's Dunfell (3.1) and Kirkstone (4.0) LTS and then also Yocto Sumo (2.5) since thats the oldest version we have supported. 

The only thing I haven't tested yet was its usage with Xilinx's Petalinux