### PR TITLE
Missing -details extension for commerical/fips building

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -125,7 +125,7 @@ BBFILE_PRIORITY_wolfssl = "5"
 
 BBFILES += "${@bb.utils.contains('WOLFSSL_TYPE', \
                                  'fips', \
-                                 '${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/fips/*.bbappend', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/fips-details/*.bbappend', \
                                  '', d)}"
 
 BBFILES += "${@bb.utils.contains('WOLFSSL_TYPE', \
@@ -135,28 +135,28 @@ BBFILES += "${@bb.utils.contains('WOLFSSL_TYPE', \
 
 BBFILES += "${@bb.utils.contains('WOLFSSL_TYPE', \
                                  'commercial', \
-                                 '${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/commercial/*.bbappend', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfssl/commercial/commercial-details/*.bbappend', \
                                  '', d)}"
 
 
 BBFILES += "${@bb.utils.contains('WOLFSSH_TYPE', \
                                  'commercial', \
-                                 '${LAYERDIR}/recipes-wolfssl/wolfssh/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfssh/commercial/commercial/*.bbappend', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfssh/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfssh/commercial/commercial-details/*.bbappend', \
                                  '', d)}"
 
 BBFILES += "${@bb.utils.contains('WOLFMQTT_TYPE', \
                                  'commerical', \
-                                 '${LAYERDIR}/recipes-wolfssl/wolfmqtt/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfmqtt/commercial/commercial/*.bbappend', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfmqtt/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfmqtt/commercial/commercial-details/*.bbappend', \
                                  '', d)}"
 
 BBFILES += "${@bb.utils.contains('WOLFCLU_TYPE', \
                                  'commercial', \
-                                 '${LAYERDIR}/recipes-wolfssl/wolfclu/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfclu/commercial/commercial/*.bbappend', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolfclu/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolfclu/commercial/commercial-details/*.bbappend', \
                                  '', d)}"
 
 BBFILES += "${@bb.utils.contains('WOLFTPM_TYPE', \
                                  'commercial', \
-                                 '${LAYERDIR}/recipes-wolfssl/wolftpm/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolftpm/commercial/commercial/*.bbappend', \
+                                 '${LAYERDIR}/recipes-wolfssl/wolftpm/commercial/*.bbappend ${LAYERDIR}/recipes-wolfssl/wolftpm/commercial/commercial-details/*.bbappend', \
                                  '', d)}"
 
 


### PR DESCRIPTION
Oversight with the last PR, forgot to add the -details extension to include the .bbappend files correctly