### PR TITLE
Updating recipes to newest versions due to wolfSSL 5.7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.vscode/*

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://benchmark.c;beginline=1;endline=20;md5=9438b59b0b9c78
 S = "${WORKDIR}/git/wolfcrypt/benchmark"
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=00e42151ca061463ba6a95adb2290f678cbca472"
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=bdd62314f00fca0e216bf8c963c8eeff6327e0cb"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://test.c;beginline=1;endline=20;md5=a642f031dcd2e607450
 S = "${WORKDIR}/git/wolfcrypt/test"
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=00e42151ca061463ba6a95adb2290f678cbca472"
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=bdd62314f00fca0e216bf8c963c8eeff6327e0cb"
 
 
 do_configure[noexec] = "1"

--- a/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.7.2.bb
+++ b/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.7.2.bb
@@ -13,7 +13,7 @@ SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
-SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=b74b0687a856237bc1b83b596c5c9a6991129d1b"
+SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=822e5654fd0ca8cfdddb374a9b7d1c7945ced2bb"
 
 
 DEPENDS += " wolfssl \

--- a/recipes-wolfssl/wolfprovider/wolfprovider_1.0.1.bb
+++ b/recipes-wolfssl/wolfprovider/wolfprovider_1.0.1.bb
@@ -10,9 +10,7 @@ DEPENDS += "util-linux-native"
 PROVIDES += "wolfprovider"
 RPROVIDES_${PN} = "wolfprovider"
 
-SRC_URI = "git://github.com/wolfssl/wolfProvider.git;protocol=https;branch=master"
-SRCREV = "${AUTOREV}"
-S = "${WORKDIR}/git"
+SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=4ca5086fd5fccefc6f65167523fd4babcf1b8f59"
 
 DEPENDS += " wolfssl \
             openssl \

--- a/recipes-wolfssl/wolfssh/wolfssh_1.4.18.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.4.18.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSING;md5=2c2d0ee3db6ceba278dd43212ed03733"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=9204ae711999facc7a6a386e1306ae5fb1506da5"
+SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=bbba8aef04cc090805d6ca5cfe0fed1120044378"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wolfssl/wolfssl-py/wolfssl-py_5.7.2.bb
+++ b/recipes-wolfssl/wolfssl-py/wolfssl-py_5.7.2.bb
@@ -11,7 +11,7 @@ SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=6ba654c216d2c2b967d8babaf72673f12c7bd73f"
+SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=754bc9bdb20c337eb7994f4a7c727a24ba788f83"
 
 
 DEPENDS += " wolfssl \

--- a/recipes-wolfssl/wolfssl/wolfssl_5.7.4.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.7.4.bb
@@ -10,7 +10,7 @@ DEPENDS += "util-linux-native"
 PROVIDES += "wolfssl"
 RPROVIDES_${PN} = "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=00e42151ca061463ba6a95adb2290f678cbca472"
+SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=bdd62314f00fca0e216bf8c963c8eeff6327e0cb"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wolfssl/wolftpm/wolftpm_3.4.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_3.4.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=1fa15951eb91a8fe89b3326077b9be6fb105edeb"
+SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=196c06cde6b3621de213cfb5e268d0b77d70fdae"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Updates recipes to the newest release versions, also changed wolfProvider to track the official number release instead of pulling from master