### PR TITLE
Fixing wolfprovider v1.0.1 compile issues

### DIFF
--- a/recipes-wolfssl/wolfprovider/wolfprovider_1.0.1.bb
+++ b/recipes-wolfssl/wolfprovider/wolfprovider_1.0.1.bb
@@ -10,7 +10,10 @@ DEPENDS += "util-linux-native"
 PROVIDES += "wolfprovider"
 RPROVIDES_${PN} = "wolfprovider"
 
-SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=4ca5086fd5fccefc6f65167523fd4babcf1b8f59"
+SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=4ca5086fd5fccefc6f65167523fd4babcf1b8f59 \
+           https://github.com/wolfSSL/wolfProvider/pull/54.patch;name=pr54"
+
+SRC_URI[pr54.sha256sum] = "07f4f2552274b8b9ea86e4cc6aefe6cbcbf35d4b7aed3f2bde8a767057dc6cd4"
 
 DEPENDS += " wolfssl \
             openssl \
@@ -18,6 +21,7 @@ DEPENDS += " wolfssl \
 
 inherit autotools pkgconfig
 
+S = "${WORKDIR}/git"
 OPENSSL_YOCTO_DIR = "${COMPONENTS_DIR}/${PACKAGE_ARCH}/openssl/usr"
 
 # Approach: Use Python to dynamically set function content based on Yocto version

--- a/recipes-wolfssl/wolfprovider/wolfssl_%.bbappend
+++ b/recipes-wolfssl/wolfprovider/wolfssl_%.bbappend
@@ -1,3 +1,3 @@
 EXTRA_OECONF += " --enable-opensslcoexist --enable-cmac --enable-keygen --enable-sha --enable-des3 --enable-aesctr --enable-aesccm --enable-x963kdf --enable-compkey --enable-certgen --enable-aeskeywrap --enable-enckeys --enable-base16 "
-CPPFLAGS += " -DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DECC_MIN_KEY_SZ=192 -DHAVE_PUBLIC_FFDHE -DWOLFSSL_DH_EXTRA"
+CPPFLAGS += " -DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DECC_MIN_KEY_SZ=192 -DHAVE_PUBLIC_FFDHE -DWOLFSSL_DH_EXTRA -DRSA_MIN_SIZE=1024"
 CPPFLAGS += " ${@'-DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER' if d.getVar('WOLFSSL_TYPE') not in ("fips", "fips-ready") else ''}"


### PR DESCRIPTION
#93 removed the setting of the S env variable, which causes compile issues, this was unintended to be removed and was an oversight not seen by the prb tests

Also wolfprovider v1.0.1 does not compile without a patch with wolfssl 5.4.4 or newer 


