### PR TITLE
Update and adding patchs for wolfssl 5.7.6 support

### DIFF
--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://benchmark.c;beginline=1;endline=20;md5=9438b59b0b9c78
 S = "${WORKDIR}/git/wolfcrypt/benchmark"
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=bdd62314f00fca0e216bf8c963c8eeff6327e0cb"
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=239b85c80438bf60d9a5b9e0ebe9ff097a760d0d"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://test.c;beginline=1;endline=20;md5=a642f031dcd2e607450
 S = "${WORKDIR}/git/wolfcrypt/test"
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=bdd62314f00fca0e216bf8c963c8eeff6327e0cb"
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=239b85c80438bf60d9a5b9e0ebe9ff097a760d0d"
 
 
 do_configure[noexec] = "1"

--- a/recipes-wolfssl/wolfclu/wolfclu_0.1.7.bb
+++ b/recipes-wolfssl/wolfclu/wolfclu_0.1.7.bb
@@ -12,7 +12,7 @@ RPROVIDES_${PN} = "wolfclu"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfclu.git;nobranch=1;protocol=https;rev=c862879aa92bba201b42ea87f5008f53febf4be3"
+SRC_URI = "git://github.com/wolfssl/wolfclu.git;nobranch=1;protocol=https;rev=cdc723cda8a72cbb9eab5ae6030f31e49249fed6"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wolfssl/wolfmqtt/wolfmqtt_1.19.2.bb
+++ b/recipes-wolfssl/wolfmqtt/wolfmqtt_1.19.2.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2c1c00f9d3ed9e24fa69b932b7e7aff2"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfMQTT.git;nobranch=1;protocol=https;rev=6db6c74675360fdc9a8c5d6705c6633a75efc95a"
+SRC_URI = "git://github.com/wolfssl/wolfMQTT.git;nobranch=1;protocol=https;rev=90790bace462d554fe35cd3d973bfe3d95d75d61"
 
 
 S = "${WORKDIR}/git"

--- a/recipes-wolfssl/wolfprovider/wolfprovider_1.0.1.bb
+++ b/recipes-wolfssl/wolfprovider/wolfprovider_1.0.1.bb
@@ -10,10 +10,7 @@ DEPENDS += "util-linux-native"
 PROVIDES += "wolfprovider"
 RPROVIDES_${PN} = "wolfprovider"
 
-SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=4ca5086fd5fccefc6f65167523fd4babcf1b8f59 \
-           https://github.com/wolfSSL/wolfProvider/pull/54.patch;name=pr54"
-
-SRC_URI[pr54.sha256sum] = "07f4f2552274b8b9ea86e4cc6aefe6cbcbf35d4b7aed3f2bde8a767057dc6cd4"
+SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=b89abe4ac89589b387a22c306c6979ce17636731"
 
 DEPENDS += " wolfssl \
             openssl \

--- a/recipes-wolfssl/wolfssh/wolfssh_1.4.19.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.4.19.bb
@@ -11,7 +11,10 @@ LIC_FILES_CHKSUM = "file://LICENSING;md5=2c2d0ee3db6ceba278dd43212ed03733"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=5305170672071dace24462b60ca656dddac1de91"
+SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=5305170672071dace24462b60ca656dddac1de91 \
+           https://github.com/wolfSSL/wolfssh/pull/766.patch;name=pr766"
+
+SRC_URI[pr766.sha256sum] = "38a4cc4242c4e67f0ac4efadb93c90fc3b8ccbfec887f1b95744c1add02f503a"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wolfssl/wolfssl/wolfssl_5.7.6.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.7.6.bb
@@ -10,7 +10,7 @@ DEPENDS += "util-linux-native"
 PROVIDES += "wolfssl"
 RPROVIDES_${PN} = "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=bdd62314f00fca0e216bf8c963c8eeff6327e0cb"
+SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=239b85c80438bf60d9a5b9e0ebe9ff097a760d0d"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wolfssl/wolftpm/wolftpm_3.8.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_3.8.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS += "wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=251ec1188e41fa9a11c22d8109963fddf7bbba72"
+SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=bcf2647ebcf76e76a75cefc46f7187d213eb1fcd"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Updating packages, wolfssh and wolfprovider require a patch to work with newest wolfssl 5.7.6. 

Updates:
wolfssl 5.7.4 to 5.7.6
wolfclu 0.1.5 to 0.1.7
wolfmqtt 1.19.1 to 1.19.2
wolfSSH 1.4.19 patched to support wolfssl 5.7.6 when using --enable-opensslcoexist
wolftpm 3.6.0 to 3.8.0
wolfprovider to master (commit b89abe4ac89589b387a22c306c6979ce17636731) 