### PR TITLE
Add newer syntax version of curl append and fix host tool DNF dependancies

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -78,8 +78,14 @@ BBFILES += "${@bb.utils.contains('IMAGE_INSTALL', \
 # Uncomment if building bind with wolfSSL.
 #BBFILES += "${LAYERDIR}/recipes-connectivity/bind/*.bbappend"
 
-# Uncomment if building curl with wolfSSL.
-#BBFILES += "${LAYERDIR}/recipes-support/curl/*.bbappend"
+# Uncomment if building any curl with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-support/curl/wolfssl_%.bbappend"
+# Uncomment if building curl 7.82.0 with wolfSSL (Kirkstone or Newer Syntax).
+#BBFILES += "${LAYERDIR}/recipes-support/curl/kirkstone/curl_7.82.0.bbappend"
+# Uncomment if building curl 7.82.0 with wolfSSL (Legacy Syntax).
+#BBFILES += "${LAYERDIR}/recipes-support/curl/curl_7.82.0.bbappend"
+# Uncomment if building any other version of curl with wolfSSL.
+#BBFILES += "${LAYERDIR}/recipes-support/curl/curl_%.bbappend"
 
 # Uncomment if building libssh2 with wolfSSL.
 #BBFILES += "${LAYERDIR}/recipes-support/libssh2/*.bbappend"

--- a/recipes-support/curl/kirkstone/curl_7.82.0.bbappend
+++ b/recipes-support/curl/kirkstone/curl_7.82.0.bbappend
@@ -1,0 +1,10 @@
+PACKAGECONFIG:remove:class-target = "openssl"
+DEPENDS:class-target += "wolfssl"
+EXTRA_OECONF:class-target += "--with-wolfssl=${STAGING_DIR_HOST}${prefix} \
+                                --with-ca-bundle=${sysconfdir}/ssl/certs/ca-certificates.crt \
+                                "
+CPPFLAGS:class-target += "-I${STAGING_DIR_HOST}${prefix}/include/wolfssl"
+
+# Uncomment the line below if you're targeting FIPS compliance. NTLM uses MD5,
+# which isn't a FIPS-approved algorithm.
+# EXTRA_OECONF:class-target += "--disable-ntlm"


### PR DESCRIPTION
When Yocto builds DNF to use as a tool on the host, to setup the rootfs of the target system, it will have some dependency chain broken. Because of that we have to say to yocto we want our edits to curl to only be applied to the target system hence `class-target` append to the compile options.

I am unsure if this is an issue with `yocto`, `curl`, `dnf` or `wolfssl` as no compiles will fail so I can only assume the toolchain breaks silently do to some missing step that is not accounted for due to the recipe changes, and this will require more in depth investigation as there should not be a reason why switching `wolfssl` in will cause this breakage.

Running host side DNF will result in python module errors otherwise:
`Could not invoke dnf` and `No module named ‘dnf’` specifcally.


Along with that I am adding a Kirstone recipe for the `curl_7.82.0.bbappend` recipe as kirkstone needs newer syntax for it's recipes.

Also adding better comments and more specific comments to `conf/layer.conf` as we should not be applying both curl append recipes as they override each other's compile options.