### PR TITLE
Curl 7.82.0 wolfSSL Patch for Kirkstone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 .vscode/*
+recipes-wolfssl/wolfssl/commercial/files/wolfssl*

--- a/recipes-support/curl/curl_7.82.0.bbappend
+++ b/recipes-support/curl/curl_7.82.0.bbappend
@@ -6,3 +6,8 @@ CPPFLAGS += "-I${STAGING_DIR_HOST}${prefix}/include/wolfssl"
 # Uncomment the line below if you're targeting FIPS compliance. NTLM uses MD5,
 # which isn't a FIPS-approved algorithm.
 # EXTRA_OECONF += "--disable-ntlm"
+
+# Add the directory where the patch is located to the search path
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
+SRC_URI += "file://wolfssl-m4-options-fix.patch"

--- a/recipes-support/curl/kirkstone/curl_7.82.0.bbappend
+++ b/recipes-support/curl/kirkstone/curl_7.82.0.bbappend
@@ -8,3 +8,8 @@ CPPFLAGS:class-target += "-I${STAGING_DIR_HOST}${prefix}/include/wolfssl"
 # Uncomment the line below if you're targeting FIPS compliance. NTLM uses MD5,
 # which isn't a FIPS-approved algorithm.
 # EXTRA_OECONF:class-target += "--disable-ntlm"
+
+# Add the directory where the patch is located to the search path
+FILESEXTRAPATHS:prepend := "${THISDIR}/../patches:"
+
+SRC_URI += "file://wolfssl-m4-options-fix.patch"

--- a/recipes-support/curl/patches/wolfssl-m4-options-fix.patch
+++ b/recipes-support/curl/patches/wolfssl-m4-options-fix.patch
@@ -1,0 +1,27 @@
+From 6657602f504e49d27b5aa667a5ed04076ac2c4f6 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 19 Jul 2022 19:22:20 -0700
+Subject: [PATCH] curl-wolfssl.m4: add options header when building test code
+
+Needed for certain configurations of wolfSSL. Otherwise, missing header
+error may occur.
+
+Tested with OpenWrt.
+
+Closes #9187
+---
+ m4/curl-wolfssl.m4 | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/m4/curl-wolfssl.m4 b/m4/curl-wolfssl.m4
+index 1f732e348ac2..9d6f561d803a 100644
+--- a/m4/curl-wolfssl.m4
++++ b/m4/curl-wolfssl.m4
+@@ -95,6 +95,7 @@ if test "x$OPT_WOLFSSL" != xno; then
+    They are set up properly later if it is detected.  */
+ #undef SIZEOF_LONG
+ #undef SIZEOF_LONG_LONG
++#include <wolfssl/options.h>
+ #include <wolfssl/ssl.h>
+ 	]],[[
+ 	  return wolfSSL_Init();


### PR DESCRIPTION
Found due to ZD 19717

When using Kirkstone, it will use Curl 7.82.0 by default.

Curl during compile will run a test compile to check that wolfSSL can be included and works.

This version of Curl does not include `#include <wolfssl/options.h>` in the test. This means that some builds of wolfSSL will fail
with an error like such:

```
/usr/include/wolfssl/wolfcrypt/wolfmath.h:38:14: fatal error: wolfssl/wolfcrypt/sp_int.h: No such file or directory
   38 |     #include <wolfssl/wolfcrypt/sp_int.h>
```

This will lead Curl to disable SSL all together, however it will not fail the build. So it can go unnoticed in the logs:
```
configure:27966: WARNING: SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.
configure:27968: WARNING: Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-nss, --with-schannel, --with-secure-transport, --with-amissl, --with-bearssl or --with-rustls to address this.
```


This was fixed in Curl in [Pull Request 9187](https://github.com/curl/curl/pull/9187)

This PR Adds a patch file and the needed hooks so that wolfSSL can compile without issue for the Curl test.

This was tested using a fips build of wolfssl which will trigger this error