### PR TITLE
Add wrynose (OpenEmbedded 5.0) compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -180,4 +180,4 @@ BBFILES += "${@bb.utils.contains('WOLFSSL_DEMOS', 'gnutls-nonfips-image-minimal'
 BBFILES += "${@bb.utils.contains('WOLFSSL_DEMOS', 'fips-image-minimal', '${LAYERDIR}/recipes-core/images/wolfssl-linux-fips-images/fips-image-minimal/*.bb ${LAYERDIR}/recipes-core/images/wolfssl-linux-fips-images/fips-image-minimal/*.bbappend', '', d)}"
 
 # Versions of OpenEmbedded-Core which layer has been tested against
-LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus hardknott gatesgarth dunfell kirkstone nanbield langdale scarthgap"
+LAYERSERIES_COMPAT_wolfssl = "sumo thud warrior zeus hardknott gatesgarth dunfell kirkstone nanbield langdale scarthgap wrynose"

--- a/inc/curl/curl-enable-wolfprovider-fips.inc
+++ b/inc/curl/curl-enable-wolfprovider-fips.inc
@@ -10,7 +10,7 @@ def curl_get_wolfprovider_fips_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/gnupg/gnupg-enable-libgcrypt-wolfssl.inc
+++ b/inc/gnupg/gnupg-enable-libgcrypt-wolfssl.inc
@@ -10,7 +10,7 @@ def gnupg_get_libgcrypt_wolfssl_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/gnutls/gnutls-enable-wolfssl.inc
+++ b/inc/gnutls/gnutls-enable-wolfssl.inc
@@ -10,7 +10,7 @@ def gnutls_get_wolfssl_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/libgcrypt/libgcrypt-enable-wolfssl.inc
+++ b/inc/libgcrypt/libgcrypt-enable-wolfssl.inc
@@ -10,7 +10,7 @@ def libgcrypt_get_wolfssl_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/libssh/libssh-enable-libgcrypt-wolfssl.inc
+++ b/inc/libssh/libssh-enable-libgcrypt-wolfssl.inc
@@ -10,7 +10,7 @@ def libssh_get_libgcrypt_wolfssl_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/nettle/nettle.inc
+++ b/inc/nettle/nettle.inc
@@ -10,7 +10,7 @@ def nettle_get_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/rsyslog/rsyslog-enable-fips-crypto.inc
+++ b/inc/rsyslog/rsyslog-enable-fips-crypto.inc
@@ -10,7 +10,7 @@ def rsyslog_get_fips_crypto_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/wolf-py-tests/wolfcrypt-py-enable-tests.inc
+++ b/inc/wolf-py-tests/wolfcrypt-py-enable-tests.inc
@@ -9,7 +9,7 @@ def wolfcrypt_py_get_tests_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolf-py-tests/wolfssl-enable-wolf-py-tests.inc
+++ b/inc/wolf-py-tests/wolfssl-enable-wolf-py-tests.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolf_py_tests_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolf-py-tests/wolfssl-py-enable-tests.inc
+++ b/inc/wolf-py-tests/wolfssl-py-enable-tests.inc
@@ -9,7 +9,7 @@ def wolfssl_py_get_tests_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfclu/wolfssl-enable-wolfclu.inc
+++ b/inc/wolfclu/wolfssl-enable-wolfclu.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfclu_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfcrypt-py/wolfssl-enable-wolfcrypt-py.inc
+++ b/inc/wolfcrypt-py/wolfssl-enable-wolfcrypt-py.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfcrypt_py_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfcryptbenchmark/wolfssl-enable-wolfcryptbenchmark.inc
+++ b/inc/wolfcryptbenchmark/wolfssl-enable-wolfcryptbenchmark.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfcryptbenchmark_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfcrypttest/wolfssl-enable-wolfcrypttest.inc
+++ b/inc/wolfcrypttest/wolfssl-enable-wolfcrypttest.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfcrypttest_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfengine/openssl/openssl-enable-wolfengine.inc
+++ b/inc/wolfengine/openssl/openssl-enable-wolfengine.inc
@@ -9,7 +9,7 @@ def openssl_get_wolfengine_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfengine/wolfssl-enable-wolfengine.inc
+++ b/inc/wolfengine/wolfssl-enable-wolfengine.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfengine_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfenginetest/wolfengine-enable-test.inc
+++ b/inc/wolfenginetest/wolfengine-enable-test.inc
@@ -9,7 +9,7 @@ def wolfengine_get_test_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfenginetest/wolfssl-enable-wolfenginetest.inc
+++ b/inc/wolfenginetest/wolfssl-enable-wolfenginetest.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfenginetest_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfpkcs11/wolfssl-enable-wolfpkcs11.inc
+++ b/inc/wolfpkcs11/wolfssl-enable-wolfpkcs11.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfpkcs11_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfprovider/openssh/openssh-enable-wolfprovider.inc
+++ b/inc/wolfprovider/openssh/openssh-enable-wolfprovider.inc
@@ -10,7 +10,7 @@ def openssh_get_wolfprovider_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/wolfprovider/openssl/openssl-enable-wolfprovider-replace-default.inc
+++ b/inc/wolfprovider/openssl/openssl-enable-wolfprovider-replace-default.inc
@@ -10,7 +10,7 @@ def openssl_get_wolfprovider_replace_default_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/wolfprovider/openssl/openssl-enable-wolfprovider.inc
+++ b/inc/wolfprovider/openssl/openssl-enable-wolfprovider.inc
@@ -10,7 +10,7 @@ def openssl_get_wolfprovider_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/wolfprovider/wolfprovider-enable-replace-default-unittest.inc
+++ b/inc/wolfprovider/wolfprovider-enable-replace-default-unittest.inc
@@ -9,7 +9,7 @@ def wolfprovider_get_replace_default_unittest_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfprovider/wolfprovider-enable-unittest.inc
+++ b/inc/wolfprovider/wolfprovider-enable-unittest.inc
@@ -9,7 +9,7 @@ def wolfprovider_get_unittest_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfprovider/wolfssl-enable-wolfprovider-fips-ready.inc
+++ b/inc/wolfprovider/wolfssl-enable-wolfprovider-fips-ready.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfprovider_fips_ready_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfprovider/wolfssl-enable-wolfprovider-fips.inc
+++ b/inc/wolfprovider/wolfssl-enable-wolfprovider-fips.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfprovider_fips_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfprovider/wolfssl-enable-wolfprovider.inc
+++ b/inc/wolfprovider/wolfssl-enable-wolfprovider.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfprovider_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssh/wolfssl-enable-wolfssh.inc
+++ b/inc/wolfssh/wolfssl-enable-wolfssh.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfssh_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssl-fips-ready/wolfssl-enable-gnutls.inc
+++ b/inc/wolfssl-fips-ready/wolfssl-enable-gnutls.inc
@@ -9,7 +9,7 @@ def wolfssl_get_fips_ready_gnutls_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssl-fips-ready/wolfssl-enable-libgcrypt.inc
+++ b/inc/wolfssl-fips-ready/wolfssl-enable-libgcrypt.inc
@@ -9,7 +9,7 @@ def wolfssl_get_fips_ready_libgcrypt_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssl-fips/wolfssl-commercial-gcs.inc
+++ b/inc/wolfssl-fips/wolfssl-commercial-gcs.inc
@@ -9,7 +9,7 @@ def wolfssl_get_commercial_gcs_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssl-fips/wolfssl-enable-gnutls.inc
+++ b/inc/wolfssl-fips/wolfssl-enable-gnutls.inc
@@ -9,7 +9,7 @@ def wolfssl_get_gnutls_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssl-fips/wolfssl-enable-libgcrypt.inc
+++ b/inc/wolfssl-fips/wolfssl-enable-libgcrypt.inc
@@ -9,7 +9,7 @@ def wolfssl_get_libgcrypt_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssl-linuxkm/wolfssl-linuxkm-sign-module.inc
+++ b/inc/wolfssl-linuxkm/wolfssl-linuxkm-sign-module.inc
@@ -9,7 +9,7 @@ def wolfssl_linuxkm_get_sign_inc(d):
     codename = None
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             codename = series
             if series in modern_series:

--- a/inc/wolfssl-manual-config.inc
+++ b/inc/wolfssl-manual-config.inc
@@ -9,7 +9,7 @@ def wolfssl_get_manual_config_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolfssl-py/wolfssl-enable-wolfssl-py.inc
+++ b/inc/wolfssl-py/wolfssl-enable-wolfssl-py.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolfssl_py_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolftpm-tests/wolfssl-enable-wolftpm-wrap-test.inc
+++ b/inc/wolftpm-tests/wolfssl-enable-wolftpm-wrap-test.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolftpm_wrap_test_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolftpm-tests/wolftpm-enable-wrap-test.inc
+++ b/inc/wolftpm-tests/wolftpm-enable-wrap-test.inc
@@ -9,7 +9,7 @@ def wolftpm_get_wrap_test_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/inc/wolftpm/wolfssl-enable-wolftpm.inc
+++ b/inc/wolftpm/wolfssl-enable-wolftpm.inc
@@ -9,7 +9,7 @@ def wolfssl_get_wolftpm_inc(d):
     use_modern = False
     if layerseries:
         series_list = layerseries.split()
-        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap']
+        modern_series = ['dunfell', 'gatesgarth', 'hardknott', 'honister', 'kirkstone', 'langdale', 'mickledore', 'nanbield', 'scarthgap', 'wrynose']
         for series in series_list:
             if series in modern_series:
                 use_modern = True

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
@@ -7,7 +7,7 @@ SECTION = "x11/applications"
 
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://benchmark.c;beginline=1;endline=20;md5=34cdd4008eba44b62a19f9700e60d888"
-S = "${WORKDIR}/git/wolfcrypt/benchmark"
+S = "${UNPACKDIR}/${BP}/wolfcrypt/benchmark"
 DEPENDS += "virtual/wolfssl"
 
 inherit wolfssl-compatibility

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
@@ -7,7 +7,7 @@ SECTION = "x11/applications"
 
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://test.c;beginline=1;endline=20;md5=881a8045bc665f7843d064f4465c360a"
-S = "${WORKDIR}/git/wolfcrypt/test"
+S = "${UNPACKDIR}/${BP}/wolfcrypt/test"
 DEPENDS += "virtual/wolfssl"
 
 inherit wolfssl-compatibility

--- a/recipes-examples/wolfprovider/wolfprovidercmd/wolfprovidercmd.bb
+++ b/recipes-examples/wolfprovider/wolfprovidercmd/wolfprovidercmd.bb
@@ -19,8 +19,6 @@ SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;r
            file://wolfprovidercmd.sh"
 
 
-S = "${WORKDIR}/git"
-
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
@@ -19,8 +19,6 @@ DEPENDS += " wolfssl-py \
 
 inherit wolfssl-compatibility
 
-S = "${WORKDIR}/git"
-
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 

--- a/recipes-examples/wolftpm/wolftpm-wrap-test.bb
+++ b/recipes-examples/wolftpm/wolftpm-wrap-test.bb
@@ -8,7 +8,6 @@ SECTION = "libs"
 
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
-S = "${WORKDIR}/git"
 DEPENDS += "virtual/wolfssl"
 
 inherit wolfssl-compatibility

--- a/recipes-wolfssl/wolfclu/wolfclu_0.1.8+master.bb
+++ b/recipes-wolfssl/wolfclu/wolfclu_0.1.8+master.bb
@@ -8,13 +8,11 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 PROVIDES += "wolfclu"
-RPROVIDES_${PN} = "wolfclu"
+RPROVIDES:${PN} = "wolfclu"
 
 DEPENDS += "virtual/wolfssl"
 
 SRC_URI = "git://github.com/wolfssl/wolfclu.git;nobranch=1;protocol=https;rev=a17667097d253c97d8f7110e214ea90e2be5e1bd"
-
-S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig wolfssl-helper wolfssl-compatibility
 

--- a/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.8.4.bb
+++ b/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.8.4.bb
@@ -33,8 +33,6 @@ python __anonymous() {
     wolfssl_varAppend(d, 'RDEPENDS', '${PN}', ' wolfssl python3 python3-cffi')
 }
 
-S = "${WORKDIR}/git"
-
 export USE_LOCAL_WOLFSSL="${STAGING_EXECPREFIXDIR}"
 # Add reproducible build flags
 CFLAGS += " -g0 -O2 -ffile-prefix-map=${WORKDIR}=."

--- a/recipes-wolfssl/wolfengine/wolfengine_1.4.0.bb
+++ b/recipes-wolfssl/wolfengine/wolfengine_1.4.0.bb
@@ -12,8 +12,6 @@ PROVIDES += "wolfengine"
 SRC_URI = "git://github.com/wolfssl/wolfengine.git;nobranch=1;protocol=https;rev=02c18e78d59c1e5a029c171a3879e99a145737ca"
 
 
-S = "${WORKDIR}/git"
-
 DEPENDS += " virtual/wolfssl \
             openssl \
             "

--- a/recipes-wolfssl/wolfmqtt/wolfmqtt_2.0.0.bb
+++ b/recipes-wolfssl/wolfmqtt/wolfmqtt_2.0.0.bb
@@ -15,8 +15,6 @@ DEPENDS += "virtual/wolfssl"
 SRC_URI = "git://github.com/wolfssl/wolfMQTT.git;nobranch=1;protocol=https;rev=88d37edd4569d07ed3896273fdea9e80a117de76"
 
 
-S = "${WORKDIR}/git"
-
 inherit autotools pkgconfig wolfssl-helper wolfssl-compatibility
 
 python __anonymous() {

--- a/recipes-wolfssl/wolfpkcs11/wolfpkcs11_2.0.0.bb
+++ b/recipes-wolfssl/wolfpkcs11/wolfpkcs11_2.0.0.bb
@@ -10,8 +10,6 @@ DEPENDS += "virtual/wolfssl"
 
 SRC_URI = "git://github.com/wolfSSL/wolfPKCS11.git;nobranch=1;protocol=https;rev=6b76537e4cc5bea0358b7059fda26d1872584be4"
 
-S = "${WORKDIR}/git"
-
 inherit autotools pkgconfig wolfssl-helper wolfssl-compatibility
 
 python __anonymous() {

--- a/recipes-wolfssl/wolfprovider/wolfprovider_1.1.1.bb
+++ b/recipes-wolfssl/wolfprovider/wolfprovider_1.1.1.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "util-linux-native"
 
 PROVIDES += "wolfprovider"
-RPROVIDES_${PN} = "wolfprovider"
+RPROVIDES:${PN} = "wolfprovider"
 
 SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=046f4ac583ca7612386f4c38ca29a9d191785aa8"
 
@@ -25,8 +25,6 @@ python __anonymous() {
     wolfssl_varAppend(d, 'FILES', '${PN}', ' ${sysconfdir}/ssl/openssl.cnf.d/wolfprovider*.conf')
     wolfssl_varAppend(d, 'INSANE_SKIP', '${PN}', ' dev-so')
 }
-
-S = "${WORKDIR}/git"
 
 # Install provider module symlink (autotools already creates libwolfprov.so symlinks)
 install_provider_module() {

--- a/recipes-wolfssl/wolfssh/wolfssh_1.4.22.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.4.22.bb
@@ -13,8 +13,6 @@ DEPENDS += "virtual/wolfssl"
 
 SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=7d4829843625eb7f59216136a9f21e1f986a8c2e"
 
-S = "${WORKDIR}/git"
-
 inherit autotools pkgconfig wolfssl-helper wolfssl-compatibility
 
 python __anonymous() {

--- a/recipes-wolfssl/wolfssl-py/wolfssl-py_5.8.4.bb
+++ b/recipes-wolfssl/wolfssl-py/wolfssl-py_5.8.4.bb
@@ -22,14 +22,12 @@ DEPENDS += " virtual/wolfssl \
              python3 \ 
            "
 
-RDEPENDS_${PN} += " wolfssl \
+RDEPENDS:${PN} += " wolfssl \
                     python3 \
                     python3-cffi \
                   "
 
 inherit setuptools3  
-
-S = "${WORKDIR}/git"
 
 export USE_LOCAL_WOLFSSL="${STAGING_EXECPREFIXDIR}"
 

--- a/recipes-wolfssl/wolfssl/wolfssl_5.9.1.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.9.1.bb
@@ -8,11 +8,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "util-linux-native"
 
 PROVIDES += "wolfssl virtual/wolfssl"
-RPROVIDES_${PN} = "wolfssl"
+RPROVIDES:${PN} = "wolfssl"
 
 SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=1d363f3adceba9d1478230ede476a37b0dcdef24"
-
-S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig wolfssl-helper
 

--- a/recipes-wolfssl/wolftpm/wolftpm_3.10.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_3.10.0.bb
@@ -14,8 +14,6 @@ DEPENDS += "virtual/wolfssl"
 
 SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=1c61ff6c826bfcf8e1094817b44735720ecff160"
 
-S = "${WORKDIR}/git"
-
 inherit autotools pkgconfig wolfssl-helper wolfssl-compatibility
 
 python __anonymous() {


### PR DESCRIPTION
wrynose is the codename for the OE-core 5.0 / Yocto 5.1 release. Several changes are required for meta-wolfssl to build cleanly on this release:

conf/layer.conf:
- Add 'wrynose' to LAYERSERIES_COMPAT_wolfssl so bitbake accepts the layer without a compatibility warning/error.

recipes-wolfssl/wolfssl/wolfssl_5.9.1.bb:
- Remove explicit 'S = "${WORKDIR}/git"'. wrynose bitbake.conf now auto-derives S from the git fetcher using ${BP} as destsuffix; setting it to ${WORKDIR}/git triggers a fatal QA error: "Using S = ${WORKDIR} is no longer supported".
- Fix RPROVIDES_${PN} -> RPROVIDES:${PN}. The underscore-based variable override syntax was removed in wrynose and causes a parse failure.

inc/wolfcrypttest/wolfssl-enable-wolfcrypttest.inc: inc/wolfcryptbenchmark/wolfssl-enable-wolfcryptbenchmark.inc:
- Add 'wrynose' to modern_series. Without this the version selector falls back to the legacy .inc file which contains do_install_append() syntax that bitbake rejects in wrynose.

recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb: recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb:
- Change S from "${WORKDIR}/git/wolfcrypt/{test,benchmark}" to "${UNPACKDIR}/${BP}/wolfcrypt/{test,benchmark}". In wrynose the git fetcher default destsuffix changed from 'git' to '${BP}', so the source tree lands at ${UNPACKDIR}/${BP}/ rather than ${WORKDIR}/git/. The old path causes do_populate_lic to fail with "LIC_FILES_CHKSUM points to an invalid file".