### PR TITLE
wolfprovider: fix cmd-test tooling and first-run FIPS detection

### DIFF
--- a/recipes-examples/wolfprovider/wolfprovidercmd/wolfprovidercmd.bb
+++ b/recipes-examples/wolfprovider/wolfprovidercmd/wolfprovidercmd.bb
@@ -12,7 +12,8 @@ DEPENDS = "openssl virtual/wolfssl wolfprovider"
 inherit wolfssl-compatibility
 
 python __anonymous() {
-    wolfssl_varSet(d, 'RDEPENDS', '${PN}', 'bash openssl wolfprovider')
+    # wrapper sources wolfproviderenv and runs the openssl CLI at runtime
+    wolfssl_varSet(d, 'RDEPENDS', '${PN}', 'bash openssl openssl-bin wolfprovider wolfproviderenv')
 }
 
 SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=046f4ac583ca7612386f4c38ca29a9d191785aa8 \
@@ -48,6 +49,7 @@ do_install() {
 
     # Copy env setup script to scripts/
     install -m 0755 ${S}/scripts/env-setup ${WOLFPROV_CMD_TEST_INSTALL_DIR}/scripts/
+    install -m 0755 ${S}/scripts/utils-general.sh ${WOLFPROV_CMD_TEST_INSTALL_DIR}/scripts/
 
     # Copy provider configuration files to root of test dir
     install -m 0644 ${S}/provider.conf ${WOLFPROV_CMD_TEST_INSTALL_DIR}/

--- a/recipes-examples/wolfprovider/wolfproviderenv/files/wolfproviderenv.sh
+++ b/recipes-examples/wolfprovider/wolfproviderenv/files/wolfproviderenv.sh
@@ -80,8 +80,13 @@ if [ -f /etc/wolfssl/fips-enabled ]; then
     fi
 fi
 # Method 2: Check runtime detection for FIPS mode
+# Load the module directly so detection works before openssl.cnf is seeded
+# (first boot); fall back to the provider listing.
 RUNTIME_FIPS=-1
-PROVIDER_FIPS=$(openssl list -providers 2>/dev/null | grep "name:" | grep -i "wolfSSL Provider FIPS")
+PROVIDER_FIPS=$(openssl list -providers -provider libwolfprov 2>/dev/null | grep "name:" | grep -i "wolfSSL Provider FIPS")
+if [ -z "$PROVIDER_FIPS" ]; then
+    PROVIDER_FIPS=$(openssl list -providers 2>/dev/null | grep "name:" | grep -i "wolfSSL Provider FIPS")
+fi
 if [ -n "$PROVIDER_FIPS" ]; then
     RUNTIME_FIPS=1
     echo "Detected wolfSSL FIPS build (runtime detection)"


### PR DESCRIPTION
Fixes two genuine bugs in the wolfProvider example tooling in meta-wolfssl. Both are independent of how wolfSSL FIPS is selected.

- `wolfprovidercmd` installs `scripts/utils-general.sh`, which `cmd-test-common.sh` sources (the command-line suite aborts with `detect_wolfprovider_mode: command not found` without it), and depends on `wolfproviderenv` + `openssl-bin` so the package runs when installed.
- `wolfproviderenv.sh` detects FIPS by loading the provider module directly, so the first run on a fresh image is correct before `openssl.cnf` has been seeded (otherwise the first run reports a spurious config/runtime FIPS mismatch).

Scope note: an earlier revision of this PR also changed `WOLFSSL_TYPE`-based FIPS handling and the commercial/fips-ready bundle recipes. Those were dropped — the documented FIPS path (`PREFERRED_PROVIDER_virtual/wolfssl = "wolfssl-fips"` via `conf/wolfssl-fips.conf`) builds and detects FIPS correctly without them; `WOLFSSL_TYPE` is the older, undocumented path.

Verified on qemux86-64: image builds and boots, `wolfprovidercmd` runs the full command-line suite.
