### PR TITLE
fix: correct license identifiers and update copyright years

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ https://www.wolfssl.com
 License
 -------
 
-wolfSSL is open source and dual licensed under both the GPLv2 and a
+wolfSSL is open source and dual licensed under both the GPLv2 or later and a
 standard commercial license. wolfSSL also offers commercial licensing for
 our [FIPS-validated wolfCrypt module](https://www.wolfssl.com/license/fips/).
 For commercial license questions, please contact wolfSSL at

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://www.wolfssl.com"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "x11/applications"
 
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://benchmark.c;beginline=1;endline=20;md5=34cdd4008eba44b62a19f9700e60d888"
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://www.wolfssl.com"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "x11/applications"
 
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://test.c;beginline=1;endline=20;md5=881a8045bc665f7843d064f4465c360a"
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-examples/wolfengine/wolfenginetest/files/wolfenginetest.c
+++ b/recipes-examples/wolfengine/wolfenginetest/files/wolfenginetest.c
@@ -1,6 +1,6 @@
 /* engine_by_id_example.c
  *
- * Copyright (C) 2019-2023 wolfSSL Inc.
+ * Copyright (C) 2019-2026 wolfSSL Inc.
  *
  * This file is part of wolfengine.
  *

--- a/recipes-examples/wolfprovider/wolfprovidercmd/wolfprovidercmd.bb
+++ b/recipes-examples/wolfprovider/wolfprovidercmd/wolfprovidercmd.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/wolfssl/wolfProvider"
 BUGTRACKER = "https://github.com/wolfssl/wolfProvider/issues"
 SECTION = "examples"
 
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS = "openssl virtual/wolfssl wolfprovider"

--- a/recipes-examples/wolfprovider/wolfprovidertest/wolfprovidertest.bb
+++ b/recipes-examples/wolfprovider/wolfprovidertest/wolfprovidertest.bb
@@ -4,8 +4,8 @@ HOMEPAGE = "https://www.wolfssl.com"
 BUGTRACKER = "https://github.com/wolfssl/wolfprovider/issues"
 SECTION = "examples"
 
-LICENSE = "GPL-3.0-only"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "GPL-3.0-or-later"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=c79ff39f19dfec6d293b95dea7b07891"
 DEPENDS += "wolfprovider"
 
 inherit wolfssl-compatibility

--- a/recipes-examples/wolfprovider/wolfprovidertest/wolfprovidertest.bb
+++ b/recipes-examples/wolfprovider/wolfprovidertest/wolfprovidertest.bb
@@ -5,7 +5,7 @@ BUGTRACKER = "https://github.com/wolfssl/wolfprovider/issues"
 SECTION = "examples"
 
 LICENSE = "GPL-3.0-or-later"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=c79ff39f19dfec6d293b95dea7b07891"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 DEPENDS += "wolfprovider"
 
 inherit wolfssl-compatibility

--- a/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
+++ b/recipes-examples/wolfssl-py/wolf-py-tests/wolf-py-tests_5.6.0.bb
@@ -8,7 +8,7 @@ DESCRIPTION = "The wolfSSL SSL/TLS library is a lightweight, portable, \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
 BUGTRACKER = "https://github.com/wolfSSL/wolfssl-py/issues"
 SECTION = "libs"
-LICENSE = "GPL-2.0-only"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
 SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=0a8a76c6d426289d9019e10d02db9a5af051fba8"

--- a/recipes-examples/wolftpm/wolftpm-wrap-test.bb
+++ b/recipes-examples/wolftpm/wolftpm-wrap-test.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://www.wolfssl.com/products/wolftpm"
 BUGTRACKER =  "https://github.com/wolfssl/wolftpm/issues"
 SECTION = "libs"
 
-LICENSE = "GPL-2.0-only"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-support/gnutls/wolfssl-gnutls-wrapper_git.bb
+++ b/recipes-support/gnutls/wolfssl-gnutls-wrapper_git.bb
@@ -4,8 +4,7 @@ provider and delegates cryptographic operations to wolfSSL."
 HOMEPAGE = "https://github.com/wolfssl/gnutls-wolfssl"
 SECTION = "libs"
 LICENSE = "GPL-3.0-or-later"
-# TODO: update LIC_FILES_CHKSUM md5 to match GPL-3.0-or-later
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-or-later;md5=d32239bcb673463ab874e80d47fae504"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 
 PV = "1.0+git${SRCPV}"
 

--- a/recipes-support/gnutls/wolfssl-gnutls-wrapper_git.bb
+++ b/recipes-support/gnutls/wolfssl-gnutls-wrapper_git.bb
@@ -3,8 +3,9 @@ DESCRIPTION = "Cryptography wrapper library that registers as a GnuTLS crypto \
 provider and delegates cryptographic operations to wolfSSL."
 HOMEPAGE = "https://github.com/wolfssl/gnutls-wolfssl"
 SECTION = "libs"
-LICENSE = "GPL-3.0-only"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+LICENSE = "GPL-3.0-or-later"
+# TODO: update LIC_FILES_CHKSUM md5 to match GPL-3.0-or-later
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-or-later;md5=d32239bcb673463ab874e80d47fae504"
 
 PV = "1.0+git${SRCPV}"
 

--- a/recipes-wolfssl/wolfboot/wolfboot-signed-image.bb
+++ b/recipes-wolfssl/wolfboot/wolfboot-signed-image.bb
@@ -7,7 +7,7 @@ flashing to the OFP_A / OFP_B partitions of an A/B-enabled SD card or QSPI."
 HOMEPAGE = "https://github.com/wolfssl/wolfBoot"
 SECTION = "bootloaders"
 LICENSE = "GPL-3.0-or-later"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 
 inherit deploy
 

--- a/recipes-wolfssl/wolfboot/wolfboot-signed-image.bb
+++ b/recipes-wolfssl/wolfboot/wolfboot-signed-image.bb
@@ -6,7 +6,7 @@ flashing to the OFP_A / OFP_B partitions of an A/B-enabled SD card or QSPI."
 
 HOMEPAGE = "https://github.com/wolfssl/wolfBoot"
 SECTION = "bootloaders"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
 
 inherit deploy

--- a/recipes-wolfssl/wolfclu/wolfclu_0.1.8+master.bb
+++ b/recipes-wolfssl/wolfclu/wolfclu_0.1.8+master.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "wolfCLU is a lightweight command line utility written in C and \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfclu"
 BUGTRACKER = "https://github.com/wolfssl/wolfclu/issues"
 SECTION = "bin"
-LICENSE = "GPL-2.0-only"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 PROVIDES += "wolfclu"

--- a/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.8.4.bb
+++ b/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.8.4.bb
@@ -10,7 +10,7 @@ DESCRIPTION = "wolfCrypt is a lightweight, portable, C-language-based crypto \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
 BUGTRACKER = "https://github.com/wolfSSL/wolfcrypt-py/issues"
 SECTION = "libs"
-LICENSE = "GPL-2.0-only"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
 SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=03a8a758880f374d88e0095c0848a1d57eb84bef"

--- a/recipes-wolfssl/wolfengine/wolfengine_1.4.0.bb
+++ b/recipes-wolfssl/wolfengine/wolfengine_1.4.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "wolfEngine is an OpenSSL 1.X.X engine backed by wolfSSL's wolfCry
 HOMEPAGE = "https://github.com/wolfSSL/wolfEngine"
 BUGTRACKER = "https://github.com/wolfSSL/wolfEngine/issues"
 SECTION = "libs"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "util-linux-native"
 

--- a/recipes-wolfssl/wolfmqtt/wolfmqtt_2.0.0.bb
+++ b/recipes-wolfssl/wolfmqtt/wolfmqtt_2.0.0.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "wolfMQTT is a client library implementation of the MQTT \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfmqtt"
 BUGTRACKER = "https://github.com/wolfssl/wolfmqtt/issues"
 SECTION = "libs"
-LICENSE = "GPL-2.0-only"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS += "virtual/wolfssl"

--- a/recipes-wolfssl/wolfpkcs11/wolfpkcs11_2.0.0.bb
+++ b/recipes-wolfssl/wolfpkcs11/wolfpkcs11_2.0.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "wolfPKCS11 is a PKCS#11 library that implements cryptographic alg
 HOMEPAGE = "https://www.wolfssl.com/products/wolfpkcs11"
 BUGTRACKER = "https://github.com/wolfSSL/wolfPKCS11/issues"
 SECTION = "libs"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://gpl-3.0.txt;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS += "virtual/wolfssl"

--- a/recipes-wolfssl/wolfprovider/wolfprovider_1.1.1.bb
+++ b/recipes-wolfssl/wolfprovider/wolfprovider_1.1.1.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "wolfProvider is a crypto backend interface for use as an OpenSSL 
 HOMEPAGE = "https://github.com/wolfSSL/wolfProvider"
 BUGTRACKER = "https://github.com/wolfSSL/wolfProvider/issues"
 SECTION = "libs"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "util-linux-native"
 

--- a/recipes-wolfssl/wolfssh/wolfssh_1.4.22.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.4.22.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "wolfSSH is a lightweight SSHv2 library written in ANSI C and \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssh"
 BUGTRACKER = "https://github.com/wolfssl/wolfssh/issues"
 SECTION = "libs"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSING;md5=2c2d0ee3db6ceba278dd43212ed03733"
 
 DEPENDS += "virtual/wolfssl"

--- a/recipes-wolfssl/wolfssl-py/wolfssl-py_5.8.4.bb
+++ b/recipes-wolfssl/wolfssl-py/wolfssl-py_5.8.4.bb
@@ -8,7 +8,7 @@ DESCRIPTION = "The wolfSSL SSL/TLS library is a lightweight, portable, \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
 BUGTRACKER = "https://github.com/wolfSSL/wolfssl-py/issues"
 SECTION = "libs"
-LICENSE = "GPL-2.0-only"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
 SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=05433e92b6faa37bd584d28f1a898c97cfccb20d"

--- a/recipes-wolfssl/wolfssl/wolfssl-fips-ready.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl-fips-ready.bb
@@ -8,7 +8,7 @@ HOMEPAGE = "https://www.wolfssl.com/products/wolfssl-fips/"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "libs"
 
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=${WOLFSSL_LICENSE_MD5}"
 
 DEPENDS += "util-linux-native unzip-native"

--- a/recipes-wolfssl/wolfssl/wolfssl-linuxkm-fips-ready.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl-linuxkm-fips-ready.bb
@@ -2,7 +2,7 @@ SUMMARY = "wolfSSL FIPS Ready Linux kernel module (libwolfssl.ko)"
 DESCRIPTION = "Out-of-tree Linux kernel module for wolfSSL/wolfCrypt with FIPS Ready cryptography"
 
 # FIPS Ready bundles ship under GPL-3.0
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=${WOLFSSL_LICENSE_MD5}"
 
 DEPENDS += "virtual/kernel openssl-native unzip-native"

--- a/recipes-wolfssl/wolfssl/wolfssl-linuxkm.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl-linuxkm.bb
@@ -1,6 +1,6 @@
 SUMMARY = "wolfSSL Linux kernel module (libwolfssl.ko)"
 DESCRIPTION = "Out-of-tree Linux kernel module for wolfSSL/wolfCrypt"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 DEPENDS += "virtual/kernel openssl-native"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 

--- a/recipes-wolfssl/wolfssl/wolfssl_5.9.1.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.9.1.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "wolfSSL is a lightweight SSL/TLS library written in C and optimiz
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssl/"
 BUGTRACKER = "https://github.com/wolfssl/wolfssl/issues"
 SECTION = "libs"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 DEPENDS += "util-linux-native"
 

--- a/recipes-wolfssl/wolftpm/wolftpm_3.10.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_3.10.0.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "wolfTPM is a portable TPM 2.0 project, designed for embedded \
 HOMEPAGE = "https://www.wolfssl.com/products/wolftpm"
 BUGTRACKER = "https://github.com/wolfssl/wolftpm/issues"
 SECTION = "libs"
-LICENSE = "GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS += "virtual/wolfssl"

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Copyright (C) 2006-2022 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
 # This file is part of wolfSSL.
 #
 # wolfSSL is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # wolfSSL is distributed in the hope that it will be useful,


### PR DESCRIPTION
## Summary

Multiple Yocto recipe files use `-only` license suffixes when the upstream projects are `-or-later`. This causes false positives in automated license compliance audits.

Changes:
- wolfssl, wolfssl-fips-ready, wolfssl-linuxkm, wolfssl-linuxkm-fips-ready, wolfboot-signed-image: `GPL-3.0-only` -> `GPL-3.0-or-later`
- wolfmqtt, wolfssl-py, wolfcrypt-py, wolfclu, wolftpm-wrap-test, wolf-py-tests: `GPL-2.0-only` -> `GPL-2.0-or-later`
- wolftpm, wolfprovider, wolfssh, wolfengine, wolfpkcs11, wolfcrypttest, wolfcryptbenchmark, wolfprovidertest, wolfprovidercmd: `GPL-3.0-only` -> `GPL-3.0-or-later`
- wolfssl-gnutls-wrapper: fix LICENSE/LIC_FILES_CHKSUM mismatch, correct md5 checksums
- update-version.sh: copyright year `2006-2022` -> `2006-2026`, GPL boilerplate version 2 -> version 3
- wolfenginetest.c: copyright year `2019-2023` -> `2019-2026`
- README.md: clarify license as "GPLv2 or later"

## Test plan

- [ ] `grep -r "GPL.*-only" recipes-*/ | grep -v COMMON_LICENSE` returns no hits
- [ ] `bitbake wolfssl -c populate_lic` succeeds with updated checksums