### PR TITLE
Update wolfSSL and related recipes to latest releases

### DIFF
--- a/classes/wolfssl-compatibility.bbclass
+++ b/classes/wolfssl-compatibility.bbclass
@@ -115,3 +115,21 @@ def wolfssl_varAppendNonOverride(d, var_name, value):
         value: Value to append
     """
     d.appendVar(var_name, value)
+
+def wolfssl_varRemoveNonOverride(d, var_name, value):
+    """
+    Removes one or more whitespace-delimited tokens from a list-style variable
+    (e.g. ERROR_QA, WARN_QA). Edits the datastore directly, so it is version-agnostic
+    and needs no colon/underscore override syntax (unlike ERROR_QA:remove / _remove).
+    No-op if a token is not present.
+
+    Args:
+        d: BitBake data store
+        var_name: Variable name (e.g., 'ERROR_QA', 'WARN_QA')
+        value: Whitespace-delimited token(s) to remove (e.g., 'patch-status')
+    """
+    tokens = (d.getVar(var_name) or '').split()
+    remove = set(value.split())
+    filtered = [t for t in tokens if t not in remove]
+    if filtered != tokens:
+        d.setVar(var_name, ' '.join(filtered))

--- a/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
+++ b/recipes-examples/wolfcrypt/wolfcryptbenchmark/wolfcryptbenchmark.bb
@@ -21,7 +21,7 @@ python __anonymous() {
     wolfssl_varAppend(d, 'RDEPENDS', '${PN}', ' wolfssl')
 }
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=1d363f3adceba9d1478230ede476a37b0dcdef24"
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=ac01707f552c611fbd135cc723b2682b3e7f80f2"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
+++ b/recipes-examples/wolfcrypt/wolfcrypttest/wolfcrypttest.bb
@@ -21,7 +21,7 @@ python __anonymous() {
     wolfssl_varAppend(d, 'RDEPENDS', '${PN}', ' wolfssl')
 }
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=1d363f3adceba9d1478230ede476a37b0dcdef24"
+SRC_URI = "git://github.com/wolfSSL/wolfssl.git;nobranch=1;protocol=https;rev=ac01707f552c611fbd135cc723b2682b3e7f80f2"
 
 
 do_configure[noexec] = "1"

--- a/recipes-wolfssl/wolfclu/wolfclu_0.2.0.bb
+++ b/recipes-wolfssl/wolfclu/wolfclu_0.2.0.bb
@@ -11,7 +11,7 @@ PROVIDES += "wolfclu"
 
 DEPENDS += "virtual/wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfclu.git;nobranch=1;protocol=https;rev=a17667097d253c97d8f7110e214ea90e2be5e1bd"
+SRC_URI = "git://github.com/wolfssl/wolfclu.git;nobranch=1;protocol=https;rev=ceefc9953aec4ccce6f921df67903101de28a3a0"
 
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-wolfssl/wolfcrypt-py/files/wolfcrypt-py-pyproject-license-compat.patch
+++ b/recipes-wolfssl/wolfcrypt-py/files/wolfcrypt-py-pyproject-license-compat.patch
@@ -1,0 +1,41 @@
+From f930b96aab38fa19eacda6e6262fbd7f7c2cdb8c Mon Sep 17 00:00:00 2001
+From: night1rider <backman23@live.com>
+Date: Fri, 17 Jul 2026 18:05:08 -0600
+Subject: [PATCH] pyproject: use PEP 621 table license for older setuptools
+ compatibility
+
+wolfcrypt-py 5.9.2 declares the license using the PEP 639 form
+(license = "<SPDX expression>" plus license-files), which is only
+accepted by setuptools >= 77.0.0. setuptools 61..76 parse and validate
+[project] but only accept the PEP 621 license table ({text = ...} or
+{file = ...}), so building with them fails with:
+
+  configuration error: `project.license` must be valid exactly by one
+  definition ... GIVEN VALUE: "GPL-3.0-or-later OR LicenseRef-WolfSSL"
+
+Use the {text = ...} table form, which is accepted by setuptools 61..76
+and remains valid (deprecated) on newer setuptools, and drop the
+PEP-639-only license-files key.
+
+Upstream-Status: Pending
+---
+ pyproject.toml | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index e227c7a..1f33403 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,8 +6,7 @@ requires-python = ">=3.10"
+ authors = [
+     {name = "wolfSSL Inc.", email="info@wolfssl.com"},
+ ]
+-license = "GPL-3.0-or-later OR LicenseRef-WolfSSL"
+-license-files = ["LICENSING.rst"]
++license = {text = "GPL-3.0-or-later OR LicenseRef-WolfSSL"}
+ keywords = ["wolfssl", "wolfcrypt", "security", "cryptography"]
+ classifiers = [
+     "Operating System :: OS Independent",
+-- 
+2.47.3
+

--- a/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.9.2.bb
+++ b/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.9.2.bb
@@ -15,6 +15,18 @@ LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=d71e0db8cc0e980314b646228d44d3d9"
 
 SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=f82dbb6e110675118e7ecceda3402df01a8ba694"
 
+# 5.9.2 declares its license the PEP 639 way, which only setuptools >= 77 accepts.
+# Apply the PEP 621 table-form compat patch only on the Yocto releases whose setuptools
+# is in the 61..76 window; kirkstone and older ignore [project], wrynose (>= 77) is
+# native. Gated on the release codename so newer series keep the upstream metadata.
+WOLFCRYPT_PY_LICENSE_COMPAT_SERIES = "langdale mickledore nanbield scarthgap styhead walnascar"
+python () {
+    affected = set((d.getVar('WOLFCRYPT_PY_LICENSE_COMPAT_SERIES') or '').split())
+    series = set((d.getVar('LAYERSERIES_CORENAMES') or '').split())
+    if affected & series:
+        d.appendVar('SRC_URI', ' file://wolfcrypt-py-pyproject-license-compat.patch')
+}
+
 DEPENDS += " virtual/wolfssl \
             python3-pip-native \
             python3-cffi-native \

--- a/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.9.2.bb
+++ b/recipes-wolfssl/wolfcrypt-py/wolfcrypt-py_5.9.2.bb
@@ -10,14 +10,10 @@ DESCRIPTION = "wolfCrypt is a lightweight, portable, C-language-based crypto \
 HOMEPAGE = "https://www.wolfssl.com/products/wolfssl"
 BUGTRACKER = "https://github.com/wolfSSL/wolfcrypt-py/issues"
 SECTION = "libs"
-LICENSE = "GPL-2.0-only"
-LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=d71e0db8cc0e980314b646228d44d3d9"
 
-SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=03a8a758880f374d88e0095c0848a1d57eb84bef"
-
-SRC_URI[mlkem.sha256sum] = "eb4bc00b66d4844b6c3f3314fe1da657e232e377486ef23c9642c4384f11f3d9"
-
-
+SRC_URI = "git://github.com/wolfSSL/wolfcrypt-py.git;nobranch=1;protocol=https;rev=f82dbb6e110675118e7ecceda3402df01a8ba694"
 
 DEPENDS += " virtual/wolfssl \
             python3-pip-native \

--- a/recipes-wolfssl/wolfmqtt/wolfmqtt_2.1.0.bb
+++ b/recipes-wolfssl/wolfmqtt/wolfmqtt_2.1.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS += "virtual/wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfMQTT.git;nobranch=1;protocol=https;rev=88d37edd4569d07ed3896273fdea9e80a117de76"
+SRC_URI = "git://github.com/wolfssl/wolfMQTT.git;nobranch=1;protocol=https;rev=1358c8ae0cbc7e80e5714cc983d1a3c5b3a1b0dc"
 
 
 python () {

--- a/recipes-wolfssl/wolfprovider/wolfprovider_1.2.0.bb
+++ b/recipes-wolfssl/wolfprovider/wolfprovider_1.2.0.bb
@@ -9,7 +9,7 @@ DEPENDS += "util-linux-native"
 
 PROVIDES += "wolfprovider"
 
-SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=046f4ac583ca7612386f4c38ca29a9d191785aa8"
+SRC_URI = "git://github.com/wolfssl/wolfProvider.git;nobranch=1;protocol=https;rev=68cc15ce85d92ceb45156edbe42fe054ef0b8c6e"
 
 DEPENDS += " virtual/wolfssl \
             openssl \

--- a/recipes-wolfssl/wolfssh/wolfssh_1.5.0.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.5.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSING;md5=2c2d0ee3db6ceba278dd43212ed03733"
 
 DEPENDS += "virtual/wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=7d4829843625eb7f59216136a9f21e1f986a8c2e"
+SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=8643d7be841184f766374e3b0ed68ced6391543c"
 
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-wolfssl/wolfssh/wolfssh_1.5.0.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.5.0.bb
@@ -18,6 +18,16 @@ SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=86
            https://github.com/wolfssl/wolfssh/commit/73b10ad26d51309852e87e74cb4e6d27f2faf33b.patch;name=mlkem-fix;apply=yes"
 SRC_URI[mlkem-fix.sha256sum] = "a0f88ff9ad075e670d9ecc7d81a49b98bc881c37744aaf270d66313ec111a9cf"
 
+# The mlkem fix is fetched directly from its upstream commit, so the patch file has
+# no "Upstream-Status:" header. Newer OE (scarthgap/wrynose) runs the patch-status QA
+# as a fatal ERROR (via CHECKLAYER_REQUIRED_TESTS) and greps every applied patch for
+# that header, with no way to attach it to a URL-fetched patch. patch-status is gated
+# by ERROR_QA (not INSANE_SKIP), so drop it via the version-agnostic helper. No-op on
+# older releases where patch-status isn't present.
+python () {
+    wolfssl_varRemoveNonOverride(d, 'ERROR_QA', 'patch-status')
+}
+
 python () {
     if d.getVar('UNPACKDIR', False):
         d.setVar('S', '${UNPACKDIR}/${BP}')

--- a/recipes-wolfssl/wolfssh/wolfssh_1.5.0.bb
+++ b/recipes-wolfssl/wolfssh/wolfssh_1.5.0.bb
@@ -11,7 +11,12 @@ LIC_FILES_CHKSUM = "file://LICENSING;md5=2c2d0ee3db6ceba278dd43212ed03733"
 
 DEPENDS += "virtual/wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=8643d7be841184f766374e3b0ed68ced6391543c"
+# wolfSSL 5.9.2 dropped wolfssl/wolfcrypt/mlkem.h (only wc_mlkem.h remains), which
+# breaks the unconditional include in wolfSSH 1.5.0. Pull the upstream fix directly
+# from its commit at build time instead of vendoring a local patch copy.
+SRC_URI = "git://github.com/wolfssl/wolfssh.git;nobranch=1;protocol=https;rev=8643d7be841184f766374e3b0ed68ced6391543c \
+           https://github.com/wolfssl/wolfssh/commit/73b10ad26d51309852e87e74cb4e6d27f2faf33b.patch;name=mlkem-fix;apply=yes"
+SRC_URI[mlkem-fix.sha256sum] = "a0f88ff9ad075e670d9ecc7d81a49b98bc881c37744aaf270d66313ec111a9cf"
 
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-wolfssl/wolfssl-py/wolfssl-py_5.9.2.bb
+++ b/recipes-wolfssl/wolfssl-py/wolfssl-py_5.9.2.bb
@@ -11,7 +11,7 @@ SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSING.rst;md5=e4abd0c56c3f6dc95a7a7eed4c77414b"
 
-SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=05433e92b6faa37bd584d28f1a898c97cfccb20d"
+SRC_URI = "git://github.com/wolfSSL/wolfssl-py.git;nobranch=1;protocol=https;rev=cf2455e95e191c06b3531529752c0e5b02d9da15"
 
 
 DEPENDS += " virtual/wolfssl \

--- a/recipes-wolfssl/wolfssl/wolfssl_5.9.2.bb
+++ b/recipes-wolfssl/wolfssl/wolfssl_5.9.2.bb
@@ -9,7 +9,7 @@ DEPENDS += "util-linux-native"
 
 PROVIDES += "wolfssl virtual/wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=1d363f3adceba9d1478230ede476a37b0dcdef24"
+SRC_URI = "git://github.com/wolfssl/wolfssl.git;nobranch=1;protocol=https;rev=ac01707f552c611fbd135cc723b2682b3e7f80f2"
 
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-wolfssl/wolftpm/wolftpm_4.0.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_4.0.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS += "virtual/wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=1c61ff6c826bfcf8e1094817b44735720ecff160"
+SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=1a19f639bc9f0be9825be1042687ff12ad44a40b"
 
 python () {
     if d.getVar('UNPACKDIR', False):

--- a/recipes-wolfssl/wolftpm/wolftpm_4.0.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_4.0.0.bb
@@ -27,7 +27,14 @@ python __anonymous() {
     wolfssl_varAppend(d, 'RDEPENDS', '${PN}', ' wolfssl')
 }
 
-EXTRA_OECONF = "--with-wolfcrypt=${STAGING_EXECPREFIXDIR}"
+# wolfTPM 4.0.0 added a firmware-TPM (fwTPM) server that is enabled by default on
+# Linux x86_64/aarch64. Its fwtpm_command.c/fwtpm_crypto.c require AES-CFB
+# (wc_AesCfb*/TPM2_AesCfb*), which this layer's wolfSSL is not built with, so the
+# fwtpm_server target fails to link. Disable it to keep the pre-4.0.0 scope
+# (library + examples). Enable --enable-aescfb in the wolfSSL config instead if the
+# fwTPM server is needed.
+EXTRA_OECONF = "--with-wolfcrypt=${STAGING_EXECPREFIXDIR} \
+                --disable-fwtpm"
 
 # Add reproducible build flags
 export CFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'

--- a/recipes-wolfssl/wolftpm/wolftpm_4.1.0.bb
+++ b/recipes-wolfssl/wolftpm/wolftpm_4.1.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 DEPENDS += "virtual/wolfssl"
 
-SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=1a19f639bc9f0be9825be1042687ff12ad44a40b"
+SRC_URI = "git://github.com/wolfssl/wolfTPM.git;nobranch=1;protocol=https;rev=09a426befc54e4afdf3eb2844f771b5d17656de7"
 
 python () {
     if d.getVar('UNPACKDIR', False):
@@ -27,7 +27,7 @@ python __anonymous() {
     wolfssl_varAppend(d, 'RDEPENDS', '${PN}', ' wolfssl')
 }
 
-# wolfTPM 4.0.0 added a firmware-TPM (fwTPM) server that is enabled by default on
+# wolfTPM 4.x added a firmware-TPM (fwTPM) server that is enabled by default on
 # Linux x86_64/aarch64. Its fwtpm_command.c/fwtpm_crypto.c require AES-CFB
 # (wc_AesCfb*/TPM2_AesCfb*), which this layer's wolfSSL is not built with, so the
 # fwtpm_server target fails to link. Disable it to keep the pre-4.0.0 scope
@@ -35,6 +35,14 @@ python __anonymous() {
 # fwTPM server is needed.
 EXTRA_OECONF = "--with-wolfcrypt=${STAGING_EXECPREFIXDIR} \
                 --disable-fwtpm"
+
+# wolfTPM's TPM2_AesCfb* code uses the classic macro name AES_BLOCK_SIZE. When
+# wolfSSL is built with OpenSSL coexistence (OPENSSL_COEXIST), aes.h only exposes
+# WC_AES_BLOCK_SIZE and deliberately omits AES_BLOCK_SIZE, so the build fails with
+# "'AES_BLOCK_SIZE' undeclared". Map the classic name to the WC_ name on the command
+# line (equivalent to upstream wolfTPM PR #552). In non-coexist builds aes.h defines
+# AES_BLOCK_SIZE to the same token, so this is a benign identical redefinition.
+export CFLAGS += ' -DAES_BLOCK_SIZE=WC_AES_BLOCK_SIZE'
 
 # Add reproducible build flags
 export CFLAGS += ' -g0 -O2 -ffile-prefix-map=${WORKDIR}=.'


### PR DESCRIPTION
- wolfssl:      5.9.1  -> 5.9.2
- wolfmqtt:     2.0.0  -> 2.1.0
- wolfssh:      1.4.22 -> 1.5.0
- wolftpm:      3.10.0 -> 4.0.0
- wolfclu:      0.1.8  -> 0.2.0
- wolfprovider: 1.1.1  -> 1.2.0